### PR TITLE
optimise: remount read-only store writable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,8 @@ dependencies = [
  "anyhow",
  "foldhash 0.2.0",
  "harmonia-store-core",
+ "log",
+ "nix",
  "rusqlite",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pico-args = "0.5"
 rayon = "1"
 walkdir = "2"
 anyhow = "1"
-nix = { version = "0.31", features = ["fs", "user", "dir", "mount"] }
+nix = { version = "0.31", features = ["fs", "user", "dir", "mount", "sched"] }
 log = { version = "0.4", features = ["std"] }
 rusqlite = "0.39"
 foldhash = "0.2"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -8,3 +8,5 @@ anyhow.workspace = true
 rusqlite.workspace = true
 foldhash.workspace = true
 harmonia-store-core.workspace = true
+nix.workspace = true
+log.workspace = true

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,5 +1,98 @@
 pub mod db;
 
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Enter a private mount namespace so the rw remount in
+/// `make_store_writable` is scoped to this process and does not leak into
+/// the system, mirroring what the `nix` CLI does for root.
+///
+/// Must be called from `main` before any thread pool is spawned:
+/// `unshare(CLONE_NEWNS)` only moves the calling thread into the new
+/// namespace, so worker threads created earlier would stay in the host
+/// namespace and not see the remount.
+///
+/// Failures are logged and ignored (e.g. EPERM in containers); we then
+/// fall back to remounting in the host namespace, like legacy `nix-store`.
+#[cfg(target_os = "linux")]
+pub fn unshare_mount_namespace() {
+    use nix::mount::{MsFlags, mount};
+    use nix::sched::{CloneFlags, unshare};
+    use nix::unistd::Uid;
+
+    if !Uid::effective().is_root() {
+        return;
+    }
+    if let Err(e) = unshare(CloneFlags::CLONE_NEWNS) {
+        log::warn!("failed to set up a private mount namespace: {e}");
+        return;
+    }
+    // Default propagation on systemd is `shared`; without this a remount
+    // would propagate back to the host namespace.
+    if let Err(e) = mount(
+        None::<&str>,
+        "/",
+        None::<&str>,
+        MsFlags::MS_PRIVATE | MsFlags::MS_REC,
+        None::<&str>,
+    ) {
+        log::warn!("failed to mark / private in mount namespace: {e}");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn unshare_mount_namespace() {}
+
+/// NixOS bind-mounts /nix/store read-only; remount rw before mutating.
+#[cfg(target_os = "linux")]
+pub fn make_store_writable(real_store_dir: &Path) -> Result<()> {
+    use nix::mount::{MsFlags, mount};
+    use nix::sys::statvfs::{FsFlags, statvfs};
+    use nix::unistd::Uid;
+
+    if !Uid::effective().is_root() {
+        return Ok(());
+    }
+
+    let st = statvfs(real_store_dir).context("getting Nix store mount info")?;
+    if !st.flags().contains(FsFlags::ST_RDONLY) {
+        return Ok(());
+    }
+
+    // Preserve locked mount flags (nodev etc.) or remount fails in a userns.
+    let mut flags = MsFlags::MS_REMOUNT | MsFlags::MS_BIND;
+    let f = st.flags();
+    for (fs_flag, ms_flag) in [
+        (FsFlags::ST_NODEV, MsFlags::MS_NODEV),
+        (FsFlags::ST_NOSUID, MsFlags::MS_NOSUID),
+        (FsFlags::ST_NOEXEC, MsFlags::MS_NOEXEC),
+        (FsFlags::ST_NOATIME, MsFlags::MS_NOATIME),
+        (FsFlags::ST_NODIRATIME, MsFlags::MS_NODIRATIME),
+        (FsFlags::ST_RELATIME, MsFlags::MS_RELATIME),
+        (FsFlags::ST_SYNCHRONOUS, MsFlags::MS_SYNCHRONOUS),
+    ] {
+        if f.contains(fs_flag) {
+            flags |= ms_flag;
+        }
+    }
+
+    mount(
+        None::<&str>,
+        real_store_dir,
+        None::<&str>,
+        flags,
+        None::<&str>,
+    )
+    .with_context(|| format!("remounting {} writable", real_store_dir.display()))?;
+    log::info!("remounted {} read-write", real_store_dir.display());
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn make_store_writable(_real_store_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
 // foldhash: SipHash showed up in profiles hashing 50-char store paths.
 pub type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
 pub type HashSet<K> = std::collections::HashSet<K, foldhash::fast::RandomState>;

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -1,64 +1,14 @@
 //! Garbage collection: liveness computation and store path deletion.
 
 use crate::db::{BasenameIndex, NixDb};
-use crate::format_size;
 use crate::roots::{find_roots, find_temp_roots};
+use crate::{format_size, make_store_writable};
 use anyhow::{Context, Result};
 use rayon::prelude::*;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
-
-/// NixOS bind-mounts /nix/store read-only; remount rw before deleting.
-#[cfg(target_os = "linux")]
-fn make_store_writable(real_store_dir: &Path) -> Result<()> {
-    use nix::mount::{MsFlags, mount};
-    use nix::sys::statvfs::{FsFlags, statvfs};
-    use nix::unistd::Uid;
-
-    if !Uid::effective().is_root() {
-        return Ok(());
-    }
-
-    let st = statvfs(real_store_dir).context("getting Nix store mount info")?;
-    if !st.flags().contains(FsFlags::ST_RDONLY) {
-        return Ok(());
-    }
-
-    // Preserve locked mount flags (nodev etc.) or remount fails in a userns.
-    let mut flags = MsFlags::MS_REMOUNT | MsFlags::MS_BIND;
-    let f = st.flags();
-    for (fs_flag, ms_flag) in [
-        (FsFlags::ST_NODEV, MsFlags::MS_NODEV),
-        (FsFlags::ST_NOSUID, MsFlags::MS_NOSUID),
-        (FsFlags::ST_NOEXEC, MsFlags::MS_NOEXEC),
-        (FsFlags::ST_NOATIME, MsFlags::MS_NOATIME),
-        (FsFlags::ST_NODIRATIME, MsFlags::MS_NODIRATIME),
-        (FsFlags::ST_RELATIME, MsFlags::MS_RELATIME),
-        (FsFlags::ST_SYNCHRONOUS, MsFlags::MS_SYNCHRONOUS),
-    ] {
-        if f.contains(fs_flag) {
-            flags |= ms_flag;
-        }
-    }
-
-    mount(
-        None::<&str>,
-        real_store_dir,
-        None::<&str>,
-        flags,
-        None::<&str>,
-    )
-    .with_context(|| format!("remounting {} writable", real_store_dir.display()))?;
-    log::info!("remounted {} read-write", real_store_dir.display());
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn make_store_writable(_real_store_dir: &Path) -> Result<()> {
-    Ok(())
-}
 
 /// Delete a store path from disk, returning bytes freed.
 /// Store paths are read-only (chmod a-w on registration); make directories

--- a/crates/gc/src/lib.rs
+++ b/crates/gc/src/lib.rs
@@ -2,4 +2,4 @@ pub mod gc;
 pub mod profiles;
 pub mod roots;
 
-pub use fast_nix_common::{HashMap, HashSet, db, format_size};
+pub use fast_nix_common::{HashMap, HashSet, db, format_size, make_store_writable};

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use fast_nix_common::unshare_mount_namespace;
 use fast_nix_gc::{db, format_size, gc, profiles};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
@@ -96,6 +97,11 @@ fn main() -> Result<()> {
     log::set_max_level(level);
 
     let args = parse_args()?;
+
+    // Before rayon spawns its global pool; see docs.
+    if !args.dry_run {
+        unshare_mount_namespace();
+    }
 
     if args.ensure_free.is_some() && args.dry_run {
         bail!("--ensure-free cannot be combined with --dry-run");

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -2,7 +2,9 @@
 
 use crate::hash::nar_hash_nix32;
 use anyhow::{Context, Result, bail};
-use fast_nix_common::{HashSet, db::NixDb, format_size};
+use fast_nix_common::{
+    HashSet, db::NixDb, format_size, make_store_writable, unshare_mount_namespace,
+};
 use harmonia_store_core::store_path::StoreDir;
 use nix::fcntl::{Flock, FlockArg};
 use std::fs;
@@ -325,6 +327,7 @@ fn shared_gc_lock(state_dir: &Path) -> Result<Flock<fs::File>> {
 pub async fn optimise_store(opts: Options) -> Result<Stats> {
     let links_dir = opts.store_dir.join(".links");
     if !opts.dry_run {
+        make_store_writable(&opts.store_dir)?;
         fs::create_dir_all(&links_dir)
             .with_context(|| format!("creating {}", links_dir.display()))?;
     }
@@ -467,6 +470,11 @@ pub fn cli_main() -> Result<()> {
     let opts = parse_args()?;
     let dry = opts.dry_run;
     let jobs = opts.jobs;
+
+    // Before tokio spawns its worker threads; see docs.
+    if !dry {
+        unshare_mount_namespace();
+    }
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(jobs)

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -59,6 +59,8 @@ pkgs.testers.runNixOSTest {
     )
     p1 = machine.succeed("nix-store --add /tmp/p1").strip()
     p2 = machine.succeed("nix-store --add /tmp/p2").strip()
+    # Force a read-only store so optimise must remount rw (issue #7).
+    machine.succeed("mount -o remount,ro,bind /nix/store")
     machine.succeed("systemctl start fast-nix-optimise.service")
     out = machine.succeed(f"stat -c %i {p1}/data {p2}/data")
     i1, i2 = out.split()


### PR DESCRIPTION

The GC binary already remounts /nix/store rw, but fast-nix-optimise did
not, causing EROFS when hardlinking into .links/ (issue #7).

Move make_store_writable into common and call it from both.
We now also enter a private mount namespace so the rw remount stays scoped to the process.

Fixes #7
