### PR TITLE
gc: batch deletion under --ensure-free

### DIFF
--- a/crates/gc/benches/gc_bench.rs
+++ b/crates/gc/benches/gc_bench.rs
@@ -26,7 +26,10 @@ impl BenchStore {
     /// - `n_paths`: total valid store paths
     /// - `n_roots`: how many are GC roots
     /// - `refs_per_path`: average references per path (capped to existing paths)
-    fn new(n_paths: usize, n_roots: usize, refs_per_path: usize) -> Self {
+    /// - `roots_at_start`: refs go i -> i-1, i-2, so tail roots keep
+    ///   everything alive. Start roots leave the rest dead, for deletion
+    ///   benchmarks.
+    fn new(n_paths: usize, n_roots: usize, refs_per_path: usize, roots_at_start: bool) -> Self {
         let dir = tempfile::tempdir().unwrap();
         let store_dir = dir.path().join("store");
         let state_dir = dir.path().join("state");
@@ -82,8 +85,12 @@ impl BenchStore {
         }
         conn.execute_batch("COMMIT;").unwrap();
 
-        // Create GC root symlinks for the last n_roots paths
-        for i in (n_paths - n_roots)..n_paths {
+        let root_range = if roots_at_start {
+            0..n_roots
+        } else {
+            (n_paths - n_roots)..n_paths
+        };
+        for i in root_range {
             let hash = format!("{:0>32x}", i);
             let name = format!("pkg-{}", i);
             let target = store_dir.join(format!("{}-{}", hash, name));
@@ -132,66 +139,126 @@ fn bench_run(label: &str, iterations: u32, f: impl Fn()) {
     );
 }
 
+/// Parse "<N> store paths deleted" from fast-nix-gc stdout.
+fn deleted_count(out: &std::process::Output) -> usize {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find_map(|l| l.strip_suffix(" freed").and_then(|l| l.split(' ').next()))
+        .and_then(|n| n.parse().ok())
+        .unwrap_or_else(|| panic!("could not parse deleted count from: {stdout}"))
+}
+
+/// Build stores up front so only the GC run is timed, and assert the
+/// deleted count so a graph with 0 dead paths fails instead of silently
+/// benchmarking a no-op.
+fn bench_delete(label: &str, iterations: u32, n_paths: usize, n_roots: usize, args: &[&str]) {
+    let expected_dead = n_paths - n_roots;
+    // +1 for warmup.
+    let mut stores: Vec<BenchStore> = (0..iterations + 1)
+        .map(|_| BenchStore::new(n_paths, n_roots, 2, true))
+        .collect();
+    let warmup = stores.pop().unwrap();
+    let out = warmup.run_gc(args);
+    assert!(out.status.success());
+    assert_eq!(
+        deleted_count(&out),
+        expected_dead,
+        "benchmark store has unexpected dead set; deletion not exercised"
+    );
+
+    let start = Instant::now();
+    for s in &stores {
+        let out = s.run_gc(args);
+        assert!(out.status.success());
+        assert_eq!(deleted_count(&out), expected_dead);
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "{:<40} {:>8.2}ms avg ({} iters, {:.2}s total, {} deleted/iter)",
+        label,
+        elapsed.as_secs_f64() * 1000.0 / iterations as f64,
+        iterations,
+        elapsed.as_secs_f64(),
+        expected_dead,
+    );
+}
+
+const SCENARIOS: &[&str] = &["small", "medium", "large", "dense", "delete", "ensure-free"];
+
 fn main() {
+    // `cargo bench` always appends `--bench`; ignore it.
+    let args: Vec<String> = std::env::args()
+        .skip(1)
+        .filter(|a| a != "--bench")
+        .collect();
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        eprintln!(
+            "usage: gc_bench [SCENARIO ...]\nscenarios: {}",
+            SCENARIOS.join(", ")
+        );
+        return;
+    }
+    for a in &args {
+        if !SCENARIOS.contains(&a.as_str()) {
+            eprintln!(
+                "unknown scenario {a:?}; available: {}",
+                SCENARIOS.join(", ")
+            );
+            std::process::exit(1);
+        }
+    }
+    let want = |s: &str| args.is_empty() || args.iter().any(|a| a == s);
+
     println!("=== fast-nix-gc benchmarks ===\n");
 
-    // Small store: 1000 paths, 10 roots, 3 refs each
-    // ~500 alive (roots + transitive closure), ~500 dead
-    println!("--- Small store (1,000 paths, 10 roots, 3 refs/path) ---");
-    {
-        let store = BenchStore::new(1_000, 10, 3);
+    if want("small") {
+        println!("--- small (1,000 paths, 10 roots, 3 refs/path) ---");
+        let store = BenchStore::new(1_000, 10, 3, false);
         bench_run("dry-run (find dead)", 10, || {
-            let out = store.run_gc(&["--dry-run"]);
-            assert!(out.status.success());
+            assert!(store.run_gc(&["--dry-run"]).status.success());
         });
     }
 
-    // Medium store: 10,000 paths, 100 roots, 5 refs each
-    println!("\n--- Medium store (10,000 paths, 100 roots, 5 refs/path) ---");
-    {
-        let store = BenchStore::new(10_000, 100, 5);
+    if want("medium") {
+        println!("\n--- medium (10,000 paths, 100 roots, 5 refs/path) ---");
+        let store = BenchStore::new(10_000, 100, 5, false);
         bench_run("dry-run (find dead)", 5, || {
-            let out = store.run_gc(&["--dry-run"]);
-            assert!(out.status.success());
+            assert!(store.run_gc(&["--dry-run"]).status.success());
         });
     }
 
-    // Large store: 50,000 paths, 500 roots, 5 refs each
-    println!("\n--- Large store (50,000 paths, 500 roots, 5 refs/path) ---");
-    {
-        let store = BenchStore::new(50_000, 500, 5);
+    if want("large") {
+        println!("\n--- large (50,000 paths, 500 roots, 5 refs/path) ---");
+        let store = BenchStore::new(50_000, 500, 5, false);
         bench_run("dry-run (find dead)", 3, || {
-            let out = store.run_gc(&["--dry-run"]);
-            assert!(out.status.success());
+            assert!(store.run_gc(&["--dry-run"]).status.success());
         });
     }
 
-    // Dense refs: 10,000 paths, 50 roots, 20 refs each
-    // Most paths alive through dense connectivity
-    println!("\n--- Dense refs (10,000 paths, 50 roots, 20 refs/path) ---");
-    {
-        let store = BenchStore::new(10_000, 50, 20);
+    if want("dense") {
+        println!("\n--- dense (10,000 paths, 50 roots, 20 refs/path) ---");
+        let store = BenchStore::new(10_000, 50, 20, false);
         bench_run("dry-run (find dead)", 5, || {
-            let out = store.run_gc(&["--dry-run"]);
-            assert!(out.status.success());
+            assert!(store.run_gc(&["--dry-run"]).status.success());
         });
     }
 
-    // Mostly dead: 10,000 paths, 5 roots, 2 refs each
-    println!("\n--- Mostly dead (10,000 paths, 5 roots, 2 refs/path) ---");
-    {
-        let store = BenchStore::new(10_000, 5, 2);
-        bench_run("dry-run (find dead)", 5, || {
-            let out = store.run_gc(&["--dry-run"]);
-            assert!(out.status.success());
-        });
+    if want("delete") {
+        println!("\n--- delete (50,000 paths, 5 roots, 2 refs/path) ---");
+        bench_delete("full GC (delete)", 3, 50_000, 5, &[]);
+    }
 
-        // Actual deletion benchmark (separate store each time)
-        bench_run("full GC (delete)", 3, || {
-            let s = BenchStore::new(10_000, 5, 2);
-            let out = s.run_gc(&[]);
-            assert!(out.status.success());
-        });
+    if want("ensure-free") {
+        println!("\n--- ensure-free (50,000 paths, 5 roots, 2 refs/path) ---");
+        // Target must exceed available space or --ensure-free is a no-op.
+        bench_delete(
+            "GC --ensure-free 9999T",
+            3,
+            50_000,
+            5,
+            &["--ensure-free", "9999T"],
+        );
     }
 
     println!("\n=== done ===");

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -211,24 +211,30 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
 
     // Bulk-invalidate, then delete from disk in parallel. Safe to crash
     // mid-delete: leftover dirs are picked up as unknown-on-disk next run.
-    //
-    // --max-freed needs actual freed bytes (narSize lies when paths share
-    // hard links), so we go one path at a time there. It's rare (auto-GC).
     let real_store_dir = db.real_store_dir.clone();
     let bytes_freed = AtomicU64::new(0);
     let mut paths_deleted = 0usize;
 
-    let chunk_size = if max_freed.is_some() {
-        1
-    } else {
-        dead_indices.len().max(1)
-    };
-
-    'outer: for chunk in dead_indices.chunks(chunk_size) {
-        if bytes_freed.load(Ordering::Relaxed) >= max {
+    // Fill each chunk by cumulative narSize up to the remaining --ensure-free
+    // budget, then re-check actual freed bytes (narSize over-reports for
+    // hard-linked paths). Without --ensure-free, max is u64::MAX: one chunk.
+    let mut cursor = 0usize;
+    while cursor < dead_indices.len() {
+        let freed_so_far = bytes_freed.load(Ordering::Relaxed);
+        if freed_so_far >= max {
             log::info!("deleted more than {max} bytes; stopping");
-            break 'outer;
+            break;
         }
+        let remaining = max - freed_so_far;
+        let mut estimated = 0u64;
+        let mut end = cursor;
+        while end < dead_indices.len() && estimated < remaining {
+            estimated = estimated.saturating_add(graph.nar_sizes[dead_indices[end] as usize]);
+            end += 1;
+        }
+        let chunk = &dead_indices[cursor..end];
+        cursor = end;
+
         db.invalidate_paths(chunk.iter().map(|&n| graph.paths[n as usize].as_str()))?;
         chunk.par_iter().for_each(|&node| {
             let path = &graph.paths[node as usize];

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -262,6 +262,29 @@ fn gc_max_freed_stops_early() {
 }
 
 #[test]
+fn gc_max_freed_batches_by_estimated_size() {
+    use fast_nix_gc::{
+        db::NixDb,
+        gc::{GcOptions, collect_garbage},
+    };
+    let store = TestStore::new();
+    // narSize 100 each, budget 250: first chunk = 3 paths (100+100+100 >= 250).
+    // Real on-disk usage exceeds 250 after that, so the loop stops at 3.
+    for i in 0..6 {
+        store.add_path(&format!("dead{i}"), 100);
+    }
+
+    let nix_db = NixDb::open(&store.store_dir, &store.state_dir).unwrap();
+    let opts = GcOptions {
+        max_freed: Some(250),
+        ..Default::default()
+    };
+    let (_, deleted) = collect_garbage(&nix_db, &opts).unwrap();
+
+    assert_eq!(deleted, 3, "first chunk must batch three paths by narSize");
+}
+
+#[test]
 fn gc_keep_recent_pins_recently_registered() {
     use fast_nix_gc::{
         db::NixDb,


### PR DESCRIPTION

With --ensure-free we deleted one path per chunk so we could check
actual freed bytes after each one. That meant one SQLite transaction
and fsync per dead path and no rayon parallelism.

Pick chunks by adding up narSize until the remaining byte budget is
covered, then delete and re-check. narSize over-reports for
hard-linked paths so the re-check is still needed, but overshoot stays
bounded to one path. Without --ensure-free the budget is u64::MAX and
everything goes in one chunk as before.
