### PR TITLE
gc: serve gc-socket so builders can register roots during GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +794,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pico-args = "0.5"
 rayon = "1"
 walkdir = "2"
 anyhow = "1"
-nix = { version = "0.31", features = ["fs", "user", "dir", "mount", "sched"] }
+nix = { version = "0.31", features = ["fs", "user", "dir", "mount", "sched", "socket"] }
 log = { version = "0.4", features = ["std"] }
 rusqlite = "0.39"
 foldhash = "0.2"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ fast-nix-optimise [OPTIONS]
 ```
 
 Both tools take a shared `gc.lock` so they don't race each other or Nix.
+While fast-nix-gc deletes, it serves the GC roots socket
+(`state/gc-socket/socket`, same protocol as `nix-store --gc`), so concurrent
+`nix build`s register temp roots without blocking on the lock.
 `--store-dir`/`--state-dir` let you point at a separate store for testing.
 
 ## NixOS module
@@ -138,8 +141,6 @@ unknown entries by the next GC.
 
 ## Not implemented
 
-- GC roots socket. Builders block on the GC lock instead of registering
-  new roots while the GC runs.
 - Reading `keep-derivations`/`keep-outputs` from `nix.conf` (defaults are
   used: `keep-derivations=true`, `keep-outputs=false`).
 

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -1,6 +1,7 @@
 //! Garbage collection: liveness computation and store path deletion.
 
 use crate::db::{BasenameIndex, NixDb};
+use crate::gc_socket::{GcSocketServer, LiveSet};
 use crate::roots::{find_roots, find_temp_roots};
 use crate::{format_size, make_store_writable};
 use anyhow::{Context, Result};
@@ -8,6 +9,7 @@ use rayon::prelude::*;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Delete a store path from disk, returning bytes freed.
@@ -116,8 +118,21 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     }
 
     log::info!("loading store graph...");
-    let graph = db.load_graph()?;
+    let graph = Arc::new(db.load_graph()?);
     log::info!("{} total valid paths", graph.len());
+
+    // Start the gc-socket as soon as the graph is loaded so builders stop
+    // busy-polling gc.lock. Roots received only shrink the dead set.
+    let live = Arc::new(LiveSet::new(graph.len(), crate::HashSet::default()));
+    let _gc_socket = if dry_run {
+        None
+    } else {
+        Some(GcSocketServer::start(
+            &db.state_dir,
+            Arc::clone(&live),
+            Arc::clone(&graph),
+        )?)
+    };
 
     let bidx = BasenameIndex::new(&graph);
 
@@ -209,11 +224,18 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
 
     log::info!("deleting garbage...");
 
+    // Test sync point: block until the named fifo is readable. The NixOS
+    // test connects to gc-socket here so the protect() path is exercised
+    // deterministically rather than racing the delete loop.
+    if let Ok(p) = std::env::var("_FAST_NIX_GC_TEST_SYNC") {
+        let _ = fs::read(&p);
+    }
+
     // Bulk-invalidate, then delete from disk in parallel. Safe to crash
     // mid-delete: leftover dirs are picked up as unknown-on-disk next run.
     let real_store_dir = db.real_store_dir.clone();
     let bytes_freed = AtomicU64::new(0);
-    let mut paths_deleted = 0usize;
+    let paths_deleted = AtomicU64::new(0);
 
     // Fill each chunk by cumulative narSize up to the remaining --ensure-free
     // budget, then re-check actual freed bytes (narSize over-reports for
@@ -234,31 +256,52 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         }
         let chunk = &dead_indices[cursor..end];
         cursor = end;
-
-        db.invalidate_paths(chunk.iter().map(|&n| graph.paths[n as usize].as_str()))?;
-        chunk.par_iter().for_each(|&node| {
-            let path = &graph.paths[node as usize];
-            let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
-            let real_path = real_store_dir.join(basename);
-            log::debug!("deleting '{path}'");
-            if let Ok(freed) = delete_store_path(&real_path) {
-                bytes_freed.fetch_add(freed, Ordering::Relaxed);
-            }
-        });
-        paths_deleted += chunk.len();
+        // Snapshot-filter, don't pre-claim: protect() should wait for the
+        // rayon-bounded in-flight set, not the whole chunk.
+        let claimed: Vec<u32> = chunk
+            .iter()
+            .copied()
+            .filter(|&n| !live.is_protected(n))
+            .collect();
+        // Disk first, DB second: paths protected between filter and unlink
+        // keep their DB entry. Crash mid-delete still self-heals via the
+        // unknown-on-disk scan next run.
+        let deleted: Vec<u32> = claimed
+            .par_iter()
+            .copied()
+            .filter(|&node| {
+                if !live.try_begin_delete_node(node) {
+                    return false;
+                }
+                let path = &graph.paths[node as usize];
+                let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
+                let real_path = real_store_dir.join(basename);
+                log::debug!("deleting '{path}'");
+                if let Ok(freed) = delete_store_path(&real_path) {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                }
+                live.end_delete_node(node);
+                true
+            })
+            .collect();
+        db.invalidate_paths(deleted.iter().map(|&n| graph.paths[n as usize].as_str()))?;
+        paths_deleted.fetch_add(deleted.len() as u64, Ordering::Relaxed);
     }
 
     // Unknown-on-disk paths: also parallel. tmp-* dirs hold flock through
     // deletion to avoid TOCTOU race with a builder.
-    let unknown_deleted = AtomicU64::new(0);
     if bytes_freed.load(Ordering::Relaxed) < max {
         unknown_on_disk.par_iter().for_each(|name| {
+            if !live.try_begin_delete_unknown(name) {
+                return;
+            }
             let real_path = real_store_dir.join(name);
             let _tmp_lock = if name.starts_with("tmp-") {
                 match try_lock_dir(&real_path) {
                     Some(f) => Some(f),
                     None => {
                         log::debug!("skipping locked tempdir {}", real_path.display());
+                        live.end_delete_unknown(name);
                         return;
                     }
                 }
@@ -269,12 +312,13 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
             if let Ok(freed) = delete_store_path(&real_path) {
                 bytes_freed.fetch_add(freed, Ordering::Relaxed);
             }
-            unknown_deleted.fetch_add(1, Ordering::Relaxed);
+            live.end_delete_unknown(name);
+            paths_deleted.fetch_add(1, Ordering::Relaxed);
         });
     }
 
     let bytes_freed = bytes_freed.into_inner();
-    paths_deleted += unknown_deleted.into_inner() as usize;
+    let paths_deleted = paths_deleted.into_inner() as usize;
 
     // Clean up unused hard links in .links
     if !dry_run {

--- a/crates/gc/src/gc_socket.rs
+++ b/crates/gc/src/gc_socket.rs
@@ -1,0 +1,381 @@
+//! GC roots socket, protocol-compatible with `nix-store --gc` (gc.cc).
+//!
+//! Builders that fail to acquire a shared `gc.lock` connect to
+//! `state/gc-socket/socket`, send newline-terminated store paths, and wait
+//! for a single `'1'` ack per line. We mark the closure protected before
+//! acking so the builder can't recreate a path we are still unlinking.
+
+use crate::db::StoreGraph;
+use crate::{HashMap, HashSet};
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+
+/// Liveness state shared between the deletion loop and the socket server.
+/// Roots from clients can only flip dead -> protected; `pending` tracks
+/// in-flight unlinks so `protect()` waits for them before acking.
+pub struct LiveSet {
+    inner: Mutex<LiveInner>,
+    cond: Condvar,
+}
+
+struct LiveInner {
+    /// Per-node "do not delete" flag, indexed by graph node id.
+    protected: Vec<bool>,
+    /// Basenames protected that are not (yet) in the graph. Covers paths a
+    /// builder registers after our DB snapshot.
+    protected_unknown: HashSet<String>,
+    /// Graph nodes currently being deleted.
+    pending_nodes: HashSet<u32>,
+    /// Unknown-on-disk basenames currently being deleted.
+    pending_unknown: HashSet<String>,
+}
+
+impl LiveSet {
+    pub fn new(n_nodes: usize, protected_unknown: HashSet<String>) -> Self {
+        LiveSet {
+            inner: Mutex::new(LiveInner {
+                protected: vec![false; n_nodes],
+                protected_unknown,
+                pending_nodes: HashSet::default(),
+                pending_unknown: HashSet::default(),
+            }),
+            cond: Condvar::new(),
+        }
+    }
+
+    /// Snapshot read; not a delete claim, does not block `protect()`.
+    pub fn is_protected(&self, node: u32) -> bool {
+        self.inner.lock().unwrap().protected[node as usize]
+    }
+
+    /// Atomically check that `node` is unprotected and mark it pending.
+    /// Returns `false` (skip deletion) if the node was protected meanwhile.
+    pub fn try_begin_delete_node(&self, node: u32) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        if g.protected[node as usize] {
+            return false;
+        }
+        g.pending_nodes.insert(node);
+        true
+    }
+
+    pub fn end_delete_node(&self, node: u32) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_nodes.remove(&node);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Same as `try_begin_delete_node` for paths not in the graph.
+    pub fn try_begin_delete_unknown(&self, basename: &str) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        if g.protected_unknown.contains(basename) {
+            return false;
+        }
+        g.pending_unknown.insert(basename.to_owned());
+        true
+    }
+
+    pub fn end_delete_unknown(&self, basename: &str) {
+        let mut g = self.inner.lock().unwrap();
+        g.pending_unknown.remove(basename);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Mark the closure of `basename` as protected and wait until none of
+    /// it is still being deleted.
+    fn protect(&self, basename: &str, graph: &StoreGraph, idx: &HashMap<String, u32>) {
+        let mut g = self.inner.lock().unwrap();
+        // Wait set is every closure node that is currently pending, not
+        // just nodes we are first to protect: an earlier overlapping
+        // protect() may have marked a node protected while it is still
+        // mid-unlink, and acking before that finishes would let the client
+        // recreate a path the deleter is about to remove.
+        let mut wait_for: Vec<u32> = Vec::new();
+        if let Some(&root) = idx.get(basename) {
+            let mut stack = vec![root];
+            let mut seen: HashSet<u32> = HashSet::default();
+            while let Some(n) = stack.pop() {
+                if !seen.insert(n) {
+                    continue;
+                }
+                g.protected[n as usize] = true;
+                if g.pending_nodes.contains(&n) {
+                    wait_for.push(n);
+                }
+                stack.extend_from_slice(graph.refs(n));
+            }
+        } else {
+            g.protected_unknown.insert(basename.to_owned());
+        }
+
+        let conflict = |g: &LiveInner| {
+            wait_for.iter().any(|n| g.pending_nodes.contains(n))
+                || g.pending_unknown.contains(basename)
+        };
+        while conflict(&g) {
+            log::debug!("synchronising with deletion of {basename}");
+            g = self.cond.wait(g).unwrap();
+        }
+    }
+}
+
+/// Running GC roots socket server. Dropping it tears down the listener,
+/// removes the socket file, and joins the accept thread.
+pub struct GcSocketServer {
+    socket_path: PathBuf,
+    listener_fd: RawFd,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl GcSocketServer {
+    /// Bind `state_dir/gc-socket/socket` and spawn the accept thread.
+    pub fn start(state_dir: &Path, live: Arc<LiveSet>, graph: Arc<StoreGraph>) -> Result<Self> {
+        let dir = state_dir.join("gc-socket");
+        fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        let socket_path = dir.join("socket");
+        // A previous GC may have crashed without cleaning up.
+        let _ = fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path)
+            .with_context(|| format!("binding {}", socket_path.display()))?;
+        // Builders may run as a different user; mirror Nix's 0666.
+        fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o666))?;
+
+        // Owned basename -> node index. BasenameIndex borrows from the graph
+        // and can't be sent across threads alongside an Arc<StoreGraph>.
+        let mut idx: HashMap<String, u32> = HashMap::default();
+        idx.reserve(graph.len());
+        for (i, p) in graph.paths.iter().enumerate() {
+            if let Some(b) = p.strip_prefix(&graph.store_prefix) {
+                idx.insert(b.to_owned(), i as u32);
+            }
+        }
+        let idx = Arc::new(idx);
+        let store_prefix = graph.store_prefix.clone();
+        let listener_fd = listener.as_raw_fd();
+
+        let handle = std::thread::Builder::new()
+            .name("gc-socket".into())
+            .spawn(move || accept_loop(listener, store_prefix, live, graph, idx))
+            .context("spawning gc-socket thread")?;
+
+        Ok(GcSocketServer {
+            socket_path,
+            listener_fd,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for GcSocketServer {
+    fn drop(&mut self) {
+        // Unlink so no new client connects, then shutdown(2) to wake the
+        // blocking accept(); unlink alone does not interrupt it.
+        let _ = fs::remove_file(&self.socket_path);
+        let _ = nix::sys::socket::shutdown(self.listener_fd, nix::sys::socket::Shutdown::Both);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn accept_loop(
+    listener: UnixListener,
+    store_prefix: String,
+    live: Arc<LiveSet>,
+    graph: Arc<StoreGraph>,
+    idx: Arc<HashMap<String, u32>>,
+) {
+    // The socket file is unlinked on shutdown; accept() then errors out.
+    while let Ok((stream, _)) = listener.accept() {
+        let store_prefix = store_prefix.clone();
+        let live = Arc::clone(&live);
+        let graph = Arc::clone(&graph);
+        let idx = Arc::clone(&idx);
+        // Each builder keeps its connection open for the duration of its
+        // build; handle them concurrently.
+        let _ = std::thread::Builder::new()
+            .name("gc-socket-conn".into())
+            .spawn(move || {
+                if let Err(e) = handle_client(stream, &store_prefix, &live, &graph, &idx) {
+                    log::debug!("gc-socket client: {e}");
+                }
+            });
+    }
+}
+
+fn handle_client(
+    stream: UnixStream,
+    store_prefix: &str,
+    live: &LiveSet,
+    graph: &StoreGraph,
+    idx: &HashMap<String, u32>,
+) -> Result<()> {
+    let mut writer = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(());
+        }
+        let path = line.trim_end_matches('\n');
+        if let Some(basename) = path.strip_prefix(store_prefix).filter(|b| !b.is_empty()) {
+            log::debug!("got new GC root '{path}'");
+            live.protect(basename, graph, idx);
+        } else {
+            log::warn!("gc-socket: received garbage instead of a root: {path:?}");
+        }
+        writer.write_all(b"1")?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    fn graph(prefix: &str, paths: &[(&str, &[u32])]) -> StoreGraph {
+        let n = paths.len();
+        let mut ref_offsets = vec![0u32; n + 1];
+        let mut ref_targets = Vec::new();
+        for (i, (_, refs)) in paths.iter().enumerate() {
+            ref_offsets[i + 1] = ref_offsets[i] + refs.len() as u32;
+            ref_targets.extend_from_slice(refs);
+        }
+        StoreGraph {
+            paths: paths.iter().map(|(p, _)| format!("{prefix}{p}")).collect(),
+            nar_sizes: vec![0; n],
+            registration_times: vec![0; n],
+            ref_offsets,
+            ref_targets,
+            store_prefix: prefix.to_owned(),
+        }
+    }
+
+    #[test]
+    fn protect_marks_closure_and_blocks_deletion() {
+        // 0 -> 1 -> 2, 3 standalone
+        let g = Arc::new(graph(
+            "/nix/store/",
+            &[("a", &[1]), ("b", &[2]), ("c", &[]), ("d", &[])],
+        ));
+        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // Closure of a (0,1,2) is protected; d (3) is still deletable.
+        assert!(!live.try_begin_delete_node(0));
+        assert!(!live.try_begin_delete_node(1));
+        assert!(!live.try_begin_delete_node(2));
+        assert!(live.try_begin_delete_node(3));
+        live.end_delete_node(3);
+
+        drop(server);
+        assert!(!sock.exists());
+    }
+
+    #[test]
+    fn protect_blocks_until_pending_delete_finishes() {
+        let g = Arc::new(graph("/nix/store/", &[("x", &[])]));
+        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Simulate the deleter claiming node 0.
+        assert!(live.try_begin_delete_node(0));
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/x\n").unwrap();
+        // The ack must not arrive until end_delete_node is called.
+        conn.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn.read_exact(&mut ack).is_err(), "ack arrived too early");
+
+        live.end_delete_node(0);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+        // After protection, a fresh delete attempt is refused.
+        assert!(!live.try_begin_delete_node(0));
+    }
+
+    #[test]
+    fn protect_waits_for_already_protected_pending_node() {
+        // Two roots a -> c and b -> c share a leaf. While c is mid-unlink,
+        // protecting a marks c protected and waits. A second protect for b
+        // must also wait for c, not ack early just because c is already
+        // protected.
+        let g = Arc::new(graph(
+            "/nix/store/",
+            &[("a", &[2]), ("b", &[2]), ("c", &[])],
+        ));
+        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // c is in flight.
+        assert!(live.try_begin_delete_node(2));
+
+        let mut conn_a = UnixStream::connect(&sock).unwrap();
+        conn_a.write_all(b"/nix/store/a\n").unwrap();
+        conn_a
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let mut ack = [0u8; 1];
+        assert!(conn_a.read_exact(&mut ack).is_err(), "a acked too early");
+
+        // c is now protected (by a's protect) but still pending. b's
+        // protect must not ack yet.
+        let mut conn_b = UnixStream::connect(&sock).unwrap();
+        conn_b.write_all(b"/nix/store/b\n").unwrap();
+        conn_b
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn_b.read_exact(&mut ack).is_err(), "b acked too early");
+
+        // c finishes; both unblock.
+        live.end_delete_node(2);
+        for conn in [&mut conn_a, &mut conn_b] {
+            conn.set_read_timeout(None).unwrap();
+            conn.read_exact(&mut ack).unwrap();
+            assert_eq!(ack, [b'1']);
+        }
+    }
+
+    #[test]
+    fn unknown_path_protected_by_basename() {
+        let g = Arc::new(graph("/nix/store/", &[]));
+        let live = Arc::new(LiveSet::new(0, HashSet::default()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/zzz-fresh\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        assert!(!live.try_begin_delete_unknown("zzz-fresh"));
+        assert!(live.try_begin_delete_unknown("other"));
+        live.end_delete_unknown("other");
+    }
+}

--- a/crates/gc/src/lib.rs
+++ b/crates/gc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod gc;
+pub mod gc_socket;
 pub mod profiles;
 pub mod roots;
 

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -24,6 +24,7 @@ pkgs.testers.runNixOSTest {
       environment.systemPackages = [
         pkgs.hello
         pkgs.sqlite
+        pkgs.socat
       ];
     };
 
@@ -49,6 +50,35 @@ pkgs.testers.runNixOSTest {
 
     # Pinned by a profile root: hello stays.
     machine.succeed("hello --version")
+
+    # gc-socket: a path registered as a root mid-GC must survive.
+    # _FAST_NIX_GC_TEST_SYNC blocks the delete loop on a fifo until we've
+    # talked to the socket; no timing race.
+    machine.succeed("echo s > /tmp/saved", "echo o > /tmp/other")
+    saved = machine.succeed("nix-store --add /tmp/saved").strip()
+    other = machine.succeed("nix-store --add /tmp/other").strip()
+    machine.succeed(
+        "sqlite3 /nix/var/nix/db/db.sqlite "
+        "'UPDATE ValidPaths SET registrationTime = 1'"
+    )
+
+    machine.succeed(
+        "mkfifo /tmp/gc-sync",
+        "mkdir -p /run/systemd/system/fast-nix-gc.service.d",
+        "printf '[Service]\\nEnvironment=_FAST_NIX_GC_TEST_SYNC=/tmp/gc-sync\\n' "
+        "> /run/systemd/system/fast-nix-gc.service.d/sync.conf",
+        "systemctl daemon-reload",
+        "systemctl start --no-block fast-nix-gc.service",
+    )
+    sock = "/nix/var/nix/gc-socket/socket"
+    machine.wait_until_succeeds(f"test -S {sock}", timeout=30)
+    ack = machine.succeed(f"echo {saved} | socat -t5 - UNIX-CONNECT:{sock}")
+    assert ack == "1", f"expected ack '1', got {ack!r}"
+    machine.succeed("echo go > /tmp/gc-sync")
+    machine.wait_until_fails("systemctl is-active fast-nix-gc.service", timeout=60)
+
+    machine.succeed(f"test -e {saved}")
+    machine.fail(f"test -e {other}")
 
     # Two store paths with an identical inner file; optimise should
     # collapse them into one inode.


### PR DESCRIPTION

While GC holds the exclusive gc.lock, builders cannot append a temp
root (that needs a shared gc.lock). Nix instead has them connect to
state/gc-socket/socket, send a store path, and wait for an ack.
Without the socket fast-nix-gc still deletes correctly, but every
concurrent build busy-polls for the lock for the whole GC run.

Implement the same protocol. New roots flip a per-node protected flag
and protect() waits for in-flight unlinks of the closure to finish,
mirroring Nix's pending sync. The delete loop snapshot-filters
protected paths and claims each node only inside the parallel
iterator, so pending stays bounded by the rayon worker count and a
client waits one unlink, not a whole chunk. Disk delete happens before
DB invalidation so a path protected mid-chunk keeps its entry.

The socket comes up right after the graph is loaded, so builders find
it before the root scan starts. Drop wakes the blocking accept() via
shutdown(2); unlinking the socket file alone doesn't interrupt it.
