### PR TITLE
gc: read keep-derivations/keep-outputs via `nix config show`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,6 @@ The GC takes the same `gc.lock` Nix does, so it won't race with
 conservative: paths gone from the DB but still on disk are picked up as
 unknown entries by the next GC.
 
-## Not implemented
-
-- Reading `keep-derivations`/`keep-outputs` from `nix.conf` (defaults are
-  used: `keep-derivations=true`, `keep-outputs=false`).
-
 ## FAQ
 
 **Could this have been implemented in upstream Nix?**

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -41,8 +41,10 @@ impl NixDb {
             state_dir: state_dir.to_path_buf(),
             real_store_dir: store_dir.to_path_buf(),
             links_dir: store_dir.join(".links"),
-            keep_derivations: true,
-            keep_outputs: false,
+            // Read the resolved nix.conf via `nix config show`; defaults
+            // match Nix if it's not in PATH.
+            keep_derivations: crate::nix_config::bool_setting("keep-derivations", true),
+            keep_outputs: crate::nix_config::bool_setting("keep-outputs", false),
         })
     }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -129,3 +129,4 @@ mod tests {
         assert_eq!(format_size(3 * 1024 * 1024 * 1024 / 2), "1.50 GiB");
     }
 }
+pub mod nix_config;

--- a/crates/common/src/nix_config.rs
+++ b/crates/common/src/nix_config.rs
@@ -1,0 +1,52 @@
+//! Read resolved nix.conf settings via `nix config show`. Reusing Nix's
+//! own config resolution avoids reimplementing the multi-file parser.
+
+use std::process::Command;
+
+/// `nix config show <key>` parsed as a bool. Returns `default` if `nix`
+/// is not in PATH, the key is unknown, or the value is not a bool.
+pub fn bool_setting(key: &str, default: bool) -> bool {
+    // `nix config show` is gated on nix-command; pass the flag so this
+    // works without it in nix.conf.
+    let out = Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command",
+            "config",
+            "show",
+            key,
+        ])
+        .output();
+    let out = match out {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return default,
+    };
+    parse_bool(&out).unwrap_or(default)
+}
+
+fn parse_bool(s: &[u8]) -> Option<bool> {
+    match std::str::from_utf8(s).ok()?.trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse() {
+        assert_eq!(parse_bool(b"true\n"), Some(true));
+        assert_eq!(parse_bool(b"false\n"), Some(false));
+        assert_eq!(parse_bool(b"42\n"), None);
+        assert_eq!(parse_bool(b""), None);
+    }
+
+    #[test]
+    fn unknown_key_falls_back_to_default() {
+        assert!(bool_setting("this-setting-does-not-exist", true));
+        assert!(!bool_setting("this-setting-does-not-exist", false));
+    }
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -156,6 +156,8 @@ in
 
       systemd.services.fast-nix-gc = {
         description = "Fast Nix Garbage Collector";
+        # `nix config show` for keep-derivations/keep-outputs.
+        path = [ config.nix.package ];
         serviceConfig = {
           Type = "oneshot";
           ExecStart = lib.escapeShellArgs (


### PR DESCRIPTION

We hardcoded the Nix defaults (keep-derivations=true,
keep-outputs=false). A user setting either in nix.conf would get
different liveness than `nix-store --gc` and risk deleting a path Nix
considers alive.

`nix config show <key>` runs Nix's full config resolution, so we don't
have to reimplement the multi-file parser. Falls back to the defaults
if `nix` is not in PATH or the key fails to parse.
