### PR TITLE
gc: re-check DB before unlinking unknown-on-disk paths

### DIFF
--- a/alloy/gc_db_consistency.als
+++ b/alloy/gc_db_consistency.als
@@ -14,6 +14,7 @@
 //   unlink + live.end_delete_node()          finishDelete
 //   chunk loop done                          chunksDone
 //   unlink unknown-on-disk entry             deleteUnknown
+//   stale temp root file removed             tempRootStale
 //   GC done                                  finishGc
 //   gc-socket protect / ack                  protectMark / protectAck
 //   builder rebuilds invalid paths           rebuild
@@ -42,8 +43,6 @@ sig Snap in Path {}
 sig Root in Path {}
 
 -- Paths with a temp root file written before GC acquired gc.lock.
--- TempRoot - Snap are shielded from the unknown-on-disk scan
--- (temp_root_basenames in gc.rs).
 sig TempRoot in Path {}
 
 fact staticStore {
@@ -65,6 +64,10 @@ fun deadSnap: set Path { Snap - aliveSnap }
 ----------------------------------------------------------------------------
 
 var sig dbValid in Path {}      -- rows in the ValidPaths table
+-- Temp root files still present (owner alive). find_temp_roots removes a
+-- file once it can flock it (owner died); only shield - Snap feeds
+-- temp_root_basenames, which shields the unknown-on-disk scan.
+var sig shield in TempRoot {}
 var sig onDisk in Path {}       -- entries present in /nix/store
 var sig protected in Path {}    -- LiveSet.protected (snapshot nodes)
 var sig protectedUnknown in Path {} -- LiveSet.protected_unknown (basenames)
@@ -88,6 +91,7 @@ one sig PC { var phase: one Phase }
 
 pred gcInit {
   dbValid = Snap
+  shield = TempRoot
   Snap in onDisk
   no protected
   no protectedUnknown
@@ -109,13 +113,27 @@ pred gcInit {
 -- (snapshot) nor in temp_root_basenames is recorded for later deletion.
 pred scanUnknown {
   PC.phase = Scanning
-  unknownList' = onDisk - Snap - TempRoot
+  unknownList' = onDisk - Snap - shield
   PC.phase' = Deleting
   -- frame
   dbValid' = dbValid and onDisk' = onDisk and protected' = protected
   protectedUnknown' = protectedUnknown and pending' = pending
   claimed' = claimed and diskDone' = diskDone and wantAck' = wantAck
-  acked' = acked and rebuilt' = rebuilt
+  acked' = acked and rebuilt' = rebuilt and shield' = shield
+}
+
+-- find_temp_roots flocks p's temp root file: the owner died, so the file
+-- is stale and removed. The owner may have registered p just before dying.
+pred tempRootStale[p: Path] {
+  PC.phase = Scanning
+  p in shield
+  shield' = shield - p
+  -- frame
+  dbValid' = dbValid and onDisk' = onDisk and protected' = protected
+  protectedUnknown' = protectedUnknown and pending' = pending
+  claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
+  wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  PC.phase' = PC.phase
 }
 
 -- One chunk: filter unclaimed dead paths against `protected`, then remove
@@ -138,6 +156,7 @@ pred chunkInvalidate {
   protectedUnknown' = protectedUnknown and pending' = pending
   diskDone' = diskDone and unknownList' = unknownList
   wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  shield' = shield
   PC.phase' = PC.phase
 }
 
@@ -151,6 +170,7 @@ pred beginDelete[p: Path] {
   protectedUnknown' = protectedUnknown and claimed' = claimed
   diskDone' = diskDone and unknownList' = unknownList
   wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  shield' = shield
   PC.phase' = PC.phase
 }
 
@@ -165,7 +185,7 @@ pred finishDelete[p: Path] {
   dbValid' = dbValid and protected' = protected
   protectedUnknown' = protectedUnknown and claimed' = claimed
   unknownList' = unknownList and wantAck' = wantAck and acked' = acked
-  rebuilt' = rebuilt and PC.phase' = PC.phase
+  rebuilt' = rebuilt and shield' = shield and PC.phase' = PC.phase
 }
 
 -- Every claimed path has been unlinked or skipped (protected); move on to
@@ -181,32 +201,37 @@ pred chunksDone {
   protectedUnknown' = protectedUnknown and pending' = pending
   claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
   wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  shield' = shield
 }
 
 -- live.try_begin_delete_unknown(p) + unlink: deletes a scanned entry unless
--- a builder protected it through the gc-socket in the meantime.
+-- a builder protected it through the gc-socket in the meantime or
+-- registered it after the graph snapshot (gc.rs re-checks ValidPaths
+-- before the unknown unlinks).
 pred deleteUnknown[p: Path] {
   PC.phase = UnknownDeleting
-  p in (unknownList & onDisk) - protectedUnknown
+  p in (unknownList & onDisk) - protectedUnknown - dbValid
   onDisk' = onDisk - p
   -- frame
   dbValid' = dbValid and protected' = protected
   protectedUnknown' = protectedUnknown and pending' = pending
   claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
   wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  shield' = shield
   PC.phase' = PC.phase
 }
 
 -- All unprotected unknown-on-disk entries are gone; GC finishes.
 pred finishGc {
   PC.phase = UnknownDeleting
-  unknownList & onDisk in protectedUnknown
+  unknownList & onDisk in protectedUnknown + dbValid
   PC.phase' = Finished
   -- frame
   dbValid' = dbValid and onDisk' = onDisk and protected' = protected
   protectedUnknown' = protectedUnknown and pending' = pending
   claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
   wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  shield' = shield
 }
 
 ----------------------------------------------------------------------------
@@ -231,7 +256,8 @@ pred protectMark[r: Path] {
   -- frame
   dbValid' = dbValid and onDisk' = onDisk and pending' = pending
   claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
-  acked' = acked and rebuilt' = rebuilt and PC.phase' = PC.phase
+  acked' = acked and rebuilt' = rebuilt and shield' = shield
+  PC.phase' = PC.phase
 }
 
 -- protect() returns and '1' is written: no closure node is mid-unlink.
@@ -245,7 +271,7 @@ pred protectAck[r: Path] {
   dbValid' = dbValid and onDisk' = onDisk and protected' = protected
   protectedUnknown' = protectedUnknown and pending' = pending
   claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
-  rebuilt' = rebuilt and PC.phase' = PC.phase
+  rebuilt' = rebuilt and shield' = shield and PC.phase' = PC.phase
 }
 
 -- The builder rebuilds what it can see is missing, walking top-down and
@@ -267,16 +293,17 @@ pred rebuild[r: Path] {
   protected' = protected and protectedUnknown' = protectedUnknown
   pending' = pending and claimed' = claimed and diskDone' = diskDone
   unknownList' = unknownList and wantAck' = wantAck and acked' = acked
+  shield' = shield
   PC.phase' = PC.phase
 }
 
 -- A builder registers a path that is not in the snapshot: store dir entry
--- plus ValidPaths row. Needs a pre-GC temp root or an acked protection,
--- and valid references.
+-- plus ValidPaths row. Needs a live temp root file (owner still alive) or
+-- an acked protection, and valid references.
 pred registerFresh[p: Path] {
   PC.phase in gcActive + Finished
   p in Path - Snap
-  p in TempRoot + (acked - Snap)
+  p in shield + (acked - Snap)
   p not in onDisk
   p.refs in dbValid
   onDisk' = onDisk + p
@@ -285,7 +312,7 @@ pred registerFresh[p: Path] {
   protected' = protected and protectedUnknown' = protectedUnknown
   pending' = pending and claimed' = claimed and diskDone' = diskDone
   unknownList' = unknownList and wantAck' = wantAck and acked' = acked
-  rebuilt' = rebuilt and PC.phase' = PC.phase
+  rebuilt' = rebuilt and shield' = shield and PC.phase' = PC.phase
 }
 
 ----------------------------------------------------------------------------
@@ -303,6 +330,7 @@ pred crash {
   protectedUnknown' = protectedUnknown and pending' = pending
   claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
   wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  shield' = shield
 }
 
 -- The next GC run after a crash, as one atomic step and without builders
@@ -319,7 +347,7 @@ pred recover {
   protected' = protected and protectedUnknown' = protectedUnknown
   pending' = pending and claimed' = claimed and diskDone' = diskDone
   unknownList' = unknownList and wantAck' = wantAck and acked' = acked
-  rebuilt' = rebuilt
+  rebuilt' = rebuilt and shield' = shield
 }
 
 pred stutter {
@@ -327,13 +355,14 @@ pred stutter {
   protectedUnknown' = protectedUnknown and pending' = pending
   claimed' = claimed and diskDone' = diskDone and unknownList' = unknownList
   wantAck' = wantAck and acked' = acked and rebuilt' = rebuilt
+  shield' = shield
   PC.phase' = PC.phase
 }
 
 pred anyEvent {
   (some p: Path | beginDelete[p] or finishDelete[p] or deleteUnknown[p]
                   or protectMark[p] or protectAck[p] or rebuild[p]
-                  or registerFresh[p])
+                  or registerFresh[p] or tempRootStale[p])
   or scanUnknown or chunkInvalidate or chunksDone or finishGc
   or crash or recover or stutter
 }
@@ -402,10 +431,9 @@ pred reachable {
   -- fresh paths enter the DB only via a temp root or an acked protection
   dbValid - Snap in TempRoot + (acked - Snap)
 
-  -- the scan never lists snapshot or temp-rooted paths, and registered
-  -- paths in the list are shielded by protected_unknown
-  unknownList in Path - Snap - TempRoot
-  unknownList & dbValid in protectedUnknown
+  -- the scan never lists snapshot paths or paths whose temp root file was
+  -- still live at scan time
+  unknownList in Path - Snap - shield
 
   -- after the scan, disk entries outside the snapshot are scanned junk,
   -- temp-rooted, or registered by an acked builder
@@ -417,7 +445,7 @@ pred reachable {
     (no unknownList and no claimed and no diskDone and no pending)
   PC.phase in UnknownDeleting + Finished implies
     (claimed in diskDone + protected and no pending)
-  PC.phase = Finished implies unknownList & onDisk in protectedUnknown
+  PC.phase = Finished implies unknownList & onDisk in protectedUnknown + dbValid
 }
 
 pred inv { safety and reachable }
@@ -441,6 +469,7 @@ run stepDeleteUnknown { inv and some p: Path | deleteUnknown[p] } for 6 but 2 st
 run stepRebuild { inv and some p: Path | rebuild[p] } for 6 but 2 steps expect 1
 run stepRegisterFresh { inv and some p: Path | registerFresh[p] } for 6 but 2 steps expect 1
 run stepRecover { inv and recover } for 6 but 2 steps expect 1
+run stepTempRootStale { inv and some p: Path | tempRootStale[p] } for 6 but 2 steps expect 1
 
 ----------------------------------------------------------------------------
 -- The proof

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -191,6 +191,16 @@ impl NixDb {
         .collect()
     }
 
+    pub fn is_valid_path(&self, path: &str) -> Result<bool> {
+        // Cached: called once per unknown-on-disk entry, which can be
+        // many thousands after an interrupted nixos-install or nix copy.
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT COUNT(*) FROM ValidPaths WHERE path = ?")?;
+        let n: i64 = stmt.query_row([path], |r| r.get(0))?;
+        Ok(n > 0)
+    }
+
     /// Remove paths from the DB in a single transaction.
     pub fn invalidate_paths<'a>(&self, paths: impl Iterator<Item = &'a str>) -> Result<()> {
         self.conn.execute_batch("BEGIN")?;

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -334,6 +334,23 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     // Unknown-on-disk paths: also parallel. tmp-* dirs hold flock through
     // deletion to avoid TOCTOU race with a builder.
     if bytes_freed.load(Ordering::Relaxed) < max {
+        // A builder may have registered a scanned path after our graph
+        // snapshot and then exited, leaving its temp root file stale.
+        // Unlinking such a path would orphan its ValidPaths row, so
+        // re-check the DB first. Checking once up front is enough: any
+        // registration from here on goes through the gc-socket and is
+        // shielded by protected_unknown. See tempRootStale in
+        // alloy/gc_db_consistency.als.
+        let mut unknown_on_disk = unknown_on_disk;
+        unknown_on_disk.retain(
+            |name| match db.is_valid_path(&format!("{store_prefix}{name}")) {
+                Ok(valid) => !valid,
+                Err(e) => {
+                    log::warn!("skipping {store_prefix}{name}: validity check failed: {e}");
+                    false
+                }
+            },
+        );
         unknown_on_disk.par_iter().for_each(|name| {
             if !live.try_begin_delete_unknown(name) {
                 return;

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -241,6 +241,72 @@ fn gc_removes_unknown_disk_entries() {
     assert!(!orphan.exists());
 }
 
+/// A path registered after the graph snapshot, whose owner exited right
+/// after the DB commit (stale temp root), shows up in the unknown-on-disk
+/// scan. GC must not unlink it: that would leave a ValidPaths row without
+/// a disk entry.
+#[test]
+fn gc_keeps_unknown_path_registered_after_snapshot() {
+    let store = TestStore::new();
+
+    // Anchor path so the store isn't empty.
+    let root = store.add_path("root", 10);
+    store.add_root("keep", &root);
+
+    // On disk before GC starts, not yet in the DB: shows up in the
+    // unknown-on-disk scan.
+    let basename = format!("{}-late", fake_hash("late"));
+    let late_path = store.store_dir.join(&basename);
+    fs::create_dir_all(&late_path).unwrap();
+    fs::write(late_path.join("file"), "data").unwrap();
+    let late_full = format!("{}/{basename}", store.store_dir.display());
+
+    // GC blocks on this fifo after the snapshot + unknown scan.
+    let fifo = store.state_dir.join("sync.fifo");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o600).unwrap()).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_fast-nix-gc"))
+        .arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .env("_FAST_NIX_GC_TEST_SYNC", &fifo)
+        .spawn()
+        .unwrap();
+
+    // Blocks until GC opened the read end, i.e. the snapshot and the
+    // unknown-on-disk scan are done.
+    let fifo_w = fs::OpenOptions::new().write(true).open(&fifo).unwrap();
+
+    // The "builder" registers the path; its temp root file is already gone.
+    store
+        .db()
+        .execute(
+            "INSERT INTO ValidPaths (path, hash, registrationTime, narSize) VALUES (?, ?, 2000, 4)",
+            rusqlite::params![late_full, format!("sha256:{}", fake_hash("late"))],
+        )
+        .unwrap();
+
+    drop(fifo_w);
+    let status = child.wait().unwrap();
+    assert!(status.success());
+
+    let in_db = store
+        .db()
+        .query_row(
+            "SELECT COUNT(*) FROM ValidPaths WHERE path = ?",
+            [&late_full],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap()
+        > 0;
+    assert!(in_db, "registered path lost its ValidPaths row");
+    assert!(
+        late_path.exists(),
+        "disk entry deleted while ValidPaths row exists (stale DB entry)"
+    );
+}
+
 #[test]
 fn gc_max_freed_stops_early() {
     use fast_nix_gc::{


### PR DESCRIPTION

A builder can register a path right after GC took its graph snapshot
and then exit, so find_temp_roots removes its temp root file as stale
and temp_root_basenames no longer shields the path. The unknown-on-disk
scan then lists it and GC unlinks the disk entry while the ValidPaths
row survives. The daemon keeps reporting the path as valid; the next
build skips it and the NAR dump dies mid-stream, desyncing the worker
protocol ("string is too long", "some outputs are unexpectedly
invalid"). Seen on eliza with a freshly built cargo-vendor-dir.

Re-check ValidPaths right before the unknown-on-disk unlinks and skip
paths that became valid since the snapshot; a later GC run picks them
up as ordinary dead paths if they really are garbage. One check up
front is enough: registrations from this point on go through the
gc-socket and protected_unknown already shields those.

The Alloy model missed this because temp root files never went stale
there. Track file liveness in a mutable shield with a tempRootStale
event; InvIsInductive then reproduces the bug, and the dbValid
precondition on deleteUnknown makes it pass again.
