### PR TITLE
gc: support CA/dynamic derivations via BuildTraceV3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 result
+/.direnv

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ fast-nix-gc [OPTIONS]
       --dry-run                 Show what would be done
       --ensure-free SIZE        Free until SIZE is available (e.g. 50G)
       --keep-recent SPEC        Keep paths registered within SPEC (e.g. 1d)
+      --keep-outputs BOOL       Override the keep-outputs nix.conf setting
+      --keep-derivations BOOL   Override the keep-derivations nix.conf setting
       --store-dir PATH          Nix store directory [default: /nix/store]
       --state-dir PATH          Nix state directory [default: /nix/var/nix]
 ```
@@ -131,8 +133,12 @@ or `nix develop -c cargo build --release`. Without flakes:
 Roots are gathered from `gcroots/`, `profiles/`, `temproots/`, and running
 processes (`/proc` on Linux; `libproc` syscalls on macOS instead of
 shelling out to `lsof`). Stale temp-root files and dangling auto-roots are
-removed. `keep-derivations` and `keep-outputs` are honored, including for
-content-addressed derivations (via the `DerivationOutputs` table). The
+removed. `keep-derivations` and `keep-outputs` are honored with the same
+edge semantics as `nix-store --gc`: an alive output keeps its derivation
+(`keep-derivations`), an alive derivation keeps its outputs
+(`keep-outputs`). This includes content-addressed / dynamic derivations:
+drv↔output mappings are read from `ValidPaths.deriver`,
+`DerivationOutputs`, and the `BuildTraceV3` table (Nix ≥2.35). The
 store is remounted read-write on NixOS where it's bind-mounted read-only.
 `tmp-*` build dirs are skipped if a builder still holds the lock.
 

--- a/alloy/gc_db_consistency.als
+++ b/alloy/gc_db_consistency.als
@@ -36,6 +36,11 @@ module gc_db_consistency
 -- Static structure
 ----------------------------------------------------------------------------
 
+-- `refs` abstracts every edge type load_graph() puts into the CSR graph:
+-- the Refs table, plus (under keep-derivations / keep-outputs) the
+-- drv↔output edges from ValidPaths.deriver, DerivationOutputs and
+-- BuildTraceV3. All of these are built with JOINs against ValidPaths, so
+-- both endpoints are always in the snapshot (staticStore below).
 sig Path { refs: set Path }
 
 -- Paths present in the DB when load_graph() took its snapshot.

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -48,6 +48,16 @@ impl NixDb {
         })
     }
 
+    /// Check whether a table exists in the SQLite database.
+    fn has_table(conn: &Connection, name: &str) -> Result<bool> {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?",
+            [name],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
     /// Load the full reference graph into memory. Walking it as an
     /// in-memory CSR is far cheaper than N point queries.
     pub fn load_graph(&self) -> Result<StoreGraph> {
@@ -109,31 +119,77 @@ impl NixDb {
         // Refs table: direct references between store paths.
         add_edges(&self.conn, "SELECT referrer, reference FROM Refs")?;
 
-        // output → deriver via ValidPaths.deriver (input-addressed)
+        // Edge directions mirror Nix's computeFSClosure (misc.cc), which
+        // the GC calls with includeOutputs = keep-outputs and
+        // includeDerivers = keep-derivations:
+        //   keep-derivations: alive output keeps its drv alive (output→drv)
+        //   keep-outputs:     alive drv keeps its outputs alive (drv→output)
+        //
+        // drv↔output mappings come from three places:
+        // - ValidPaths.deriver (all Nix versions; also covers CA outputs of
+        //   Nix ≤2.34, whose Realisations table keys drvPath by content
+        //   hash and so can't be joined against ValidPaths)
+        // - DerivationOutputs (input-addressed)
+        // - BuildTraceV3 (CA/dynamic derivations, Nix ≥2.35): drvPath is a
+        //   store path *basename*, outputPath a full store path. Created
+        //   lazily; skip if absent.
+        let has_build_trace = (self.keep_derivations || self.keep_outputs)
+            && Self::has_table(&self.conn, "BuildTraceV3")?;
+        let store_prefix = format!("{}/", self.store_dir.display());
+
         if self.keep_derivations {
+            // output → drv via ValidPaths.deriver
             add_edges(
                 &self.conn,
                 "SELECT v.id, d.id FROM ValidPaths v \
                  JOIN ValidPaths d ON d.path = v.deriver \
                  WHERE v.deriver IS NOT NULL",
             )?;
-        }
-
-        // output ↔ drv via DerivationOutputs (content-addressed).
-        // keep-derivations: output→drv and drv→output.
-        // keep-outputs: output→drv and drv→output.
-        // Both need the same two edge sets, so add each at most once.
-        if self.keep_derivations || self.keep_outputs {
+            // output → drv via DerivationOutputs (covers outputs whose
+            // deriver column is unset)
             add_edges(
                 &self.conn,
                 "SELECT o.id, do2.drv FROM ValidPaths o \
                  JOIN DerivationOutputs do2 ON do2.path = o.path",
             )?;
+            if has_build_trace {
+                // output → drv via BuildTraceV3
+                add_edges(
+                    &self.conn,
+                    &format!(
+                        "SELECT o.id, d.id FROM BuildTraceV3 bt \
+                         JOIN ValidPaths o ON o.path = bt.outputPath \
+                         JOIN ValidPaths d ON d.path = '{store_prefix}' || bt.drvPath"
+                    ),
+                )?;
+            }
+        }
+
+        if self.keep_outputs {
+            // drv → output via DerivationOutputs
             add_edges(
                 &self.conn,
                 "SELECT do2.drv, o.id FROM DerivationOutputs do2 \
                  JOIN ValidPaths o ON o.path = do2.path",
             )?;
+            // drv → output via ValidPaths.deriver
+            add_edges(
+                &self.conn,
+                "SELECT d.id, v.id FROM ValidPaths v \
+                 JOIN ValidPaths d ON d.path = v.deriver \
+                 WHERE v.deriver IS NOT NULL",
+            )?;
+            if has_build_trace {
+                // drv → output via BuildTraceV3
+                add_edges(
+                    &self.conn,
+                    &format!(
+                        "SELECT d.id, o.id FROM BuildTraceV3 bt \
+                         JOIN ValidPaths d ON d.path = '{store_prefix}' || bt.drvPath \
+                         JOIN ValidPaths o ON o.path = bt.outputPath"
+                    ),
+                )?;
+            }
         }
 
         self.conn.execute_batch("COMMIT")?;

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -10,6 +10,8 @@ struct Args {
     dry_run: bool,
     ensure_free: Option<u64>,
     keep_recent: Option<String>,
+    keep_outputs: Option<bool>,
+    keep_derivations: Option<bool>,
     store_dir: PathBuf,
     state_dir: PathBuf,
 }
@@ -48,6 +50,8 @@ fn parse_args() -> Result<Args> {
         eprintln!("      --dry-run                 Show what would be done");
         eprintln!("      --ensure-free SIZE           Free until SIZE is available (e.g. 50G)");
         eprintln!("      --keep-recent SPEC        Keep paths registered within SPEC (e.g. 7d)");
+        eprintln!("      --keep-outputs BOOL       Override the keep-outputs nix.conf setting");
+        eprintln!("      --keep-derivations BOOL   Override the keep-derivations nix.conf setting");
         eprintln!("      --store-dir PATH          Nix store directory [default: /nix/store]");
         eprintln!("      --state-dir PATH          Nix state directory [default: /nix/var/nix]");
         std::process::exit(0);
@@ -63,6 +67,8 @@ fn parse_args() -> Result<Args> {
         dry_run: pargs.contains("--dry-run"),
         ensure_free: pargs.opt_value_from_fn("--ensure-free", parse_size)?,
         keep_recent: pargs.opt_value_from_str("--keep-recent")?,
+        keep_outputs: pargs.opt_value_from_str("--keep-outputs")?,
+        keep_derivations: pargs.opt_value_from_str("--keep-derivations")?,
         store_dir: pargs
             .opt_value_from_str("--store-dir")?
             .unwrap_or_else(|| PathBuf::from("/nix/store")),
@@ -147,7 +153,13 @@ fn main() -> Result<()> {
                 .unwrap_or(0)
         });
 
-    let store = db::NixDb::open(&args.store_dir, &args.state_dir)?;
+    let mut store = db::NixDb::open(&args.store_dir, &args.state_dir)?;
+    if let Some(v) = args.keep_outputs {
+        store.keep_outputs = v;
+    }
+    if let Some(v) = args.keep_derivations {
+        store.keep_derivations = v;
+    }
     let opts = gc::GcOptions {
         dry_run: args.dry_run,
         max_freed,

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -122,6 +122,34 @@ impl TestStore {
             .unwrap();
     }
 
+    /// Insert a BuildTraceV3 row (Nix ≥2.35 schema: drvPath is a store
+    /// path basename, outputPath is a full store path).
+    fn add_build_trace(&self, drv: &Pkg, output_name: &str, out: &Pkg) {
+        let conn = self.db();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS BuildTraceV3 (
+                id integer primary key autoincrement not null,
+                drvPath text not null,
+                outputName text not null,
+                outputPath text not null,
+                signatures text
+            );
+            CREATE INDEX IF NOT EXISTS IndexBuildTraceV3 ON BuildTraceV3(drvPath, outputName);",
+        )
+        .unwrap();
+        // drvPath is a basename (no store dir prefix), matching Nix's
+        // DrvOutput::to_string() which skips the store dir.
+        let drv_basename = drv
+            .full
+            .strip_prefix(&format!("{}/", self.store_dir.display()))
+            .unwrap_or(&drv.full);
+        conn.execute(
+            "INSERT INTO BuildTraceV3 (drvPath, outputName, outputPath) VALUES (?, ?, ?)",
+            rusqlite::params![drv_basename, output_name, out.full],
+        )
+        .unwrap();
+    }
+
     fn add_root(&self, root_name: &str, target: &Pkg) {
         let link = self.state_dir.join("gcroots").join(root_name);
         std::os::unix::fs::symlink(&target.path, &link).unwrap();
@@ -157,6 +185,11 @@ impl TestStore {
             String::from_utf8_lossy(&out.stderr)
         );
         out
+    }
+
+    /// Run GC with keep-outputs enabled via CLI flag.
+    fn run_gc_keep_outputs_ok(&self) -> std::process::Output {
+        self.run_gc_ok(&["--keep-outputs", "true"])
     }
 }
 
@@ -602,9 +635,9 @@ fn gc_keeps_ca_outputs_of_alive_drv() {
     store.add_root("drv-root", &drv);
     let trash = store.add_path("trash", 100);
 
-    store.run_gc_ok(&[]);
+    store.run_gc_keep_outputs_ok();
 
-    // keep-derivations: alive .drv keeps its outputs alive.
+    // keep-outputs: alive .drv keeps its outputs alive.
     assert!(drv.path.exists(), "drv deleted");
     assert!(out.path.exists(), "CA output deleted despite alive drv");
     assert!(!trash.path.exists());
@@ -696,4 +729,48 @@ fn gc_empty_store_is_noop() {
     let out = store.run_gc_ok(&[]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("0 store paths deleted"), "stdout: {stdout}");
+}
+
+#[test]
+fn gc_keeps_ca_output_via_build_trace() {
+    // Dynamic / CA derivation: BuildTraceV3 maps drv→output.
+    // With keep-outputs, alive drv keeps its CA output via BuildTraceV3.
+    let store = TestStore::new();
+
+    let drv = store.add_path("dyn-pkg.drv", 50);
+    let out = store.add_path("dyn-pkg-out", 200);
+    // No DerivationOutputs entry — only BuildTraceV3.
+    store.add_build_trace(&drv, "out", &out);
+    store.add_root("drv-root", &drv);
+    let trash = store.add_path("trash", 100);
+
+    store.run_gc_keep_outputs_ok();
+
+    assert!(drv.path.exists(), "drv deleted");
+    assert!(
+        out.path.exists(),
+        "CA output deleted despite alive drv (BuildTraceV3)"
+    );
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_keeps_ca_deriver_via_build_trace() {
+    // Alive CA output should keep its drv alive via BuildTraceV3.
+    let store = TestStore::new();
+
+    let drv = store.add_path("dyn-pkg.drv", 50);
+    let out = store.add_path("dyn-pkg-out", 200);
+    store.add_build_trace(&drv, "out", &out);
+    store.add_root("out-root", &out);
+    let trash = store.add_path("trash", 100);
+
+    store.run_gc_ok(&[]);
+
+    assert!(out.path.exists(), "output deleted");
+    assert!(
+        drv.path.exists(),
+        "CA deriver deleted despite alive output (BuildTraceV3)"
+    );
+    assert!(!trash.path.exists());
 }

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -13,6 +13,9 @@ pkgs.testers.runNixOSTest {
         keepRecent = "1h";
       };
       services.fast-nix-optimise.enable = true;
+      # The CA test phases root a .drv and expect its output to survive,
+      # which requires keep-outputs (mirrors nix-store --gc semantics).
+      nix.settings.keep-outputs = true;
       # nix-store --optimise (and ours) cannot rename hardlinks across an
       # overlayfs lower/upper boundary: ESTALE on the 9p host store. A
       # store image avoids that, but the overlay upper is still tmpfs and
@@ -21,6 +24,9 @@ pkgs.testers.runNixOSTest {
       virtualisation.useNixStoreImage = true;
       virtualisation.writableStore = true;
       virtualisation.memorySize = 2048;
+      # nix from git for the BuildTraceV3 test phase; referenced by store
+      # path in the test script, so it must be in the VM's closure.
+      virtualisation.additionalPaths = [ pkgs.nixVersions.git ];
       environment.systemPackages = [
         pkgs.hello
         pkgs.sqlite
@@ -31,6 +37,120 @@ pkgs.testers.runNixOSTest {
   testScript = ''
     machine.start()
     machine.wait_for_unit("multi-user.target")
+
+    # --- CA derivations: realisation tables must keep drv↔output alive ---
+    # Build a CA derivation directly in the system store.
+    ca_drv_expr = (
+        'derivation { '
+        'name = "ca-test"; system = "${pkgs.system}"; '
+        'builder = "/bin/sh"; args = ["-c" "echo hello > $out"]; '
+        '__contentAddressed = true; outputHashMode = "recursive"; '
+        'outputHashAlgo = "sha256"; }'
+    )
+    ca_out = machine.succeed(
+        "nix-build"
+        ' --option experimental-features "nix-command ca-derivations"'
+        " --no-out-link"
+        f" -E '{ca_drv_expr}'"
+    ).strip()
+    ca_db = "/nix/var/nix/db/db.sqlite"
+
+    ca_drv = machine.succeed(
+        f"sqlite3 {ca_db} "
+        f"\"SELECT path FROM ValidPaths WHERE path LIKE '%ca-test.drv'\""
+    ).strip()
+    assert ca_drv, "drv not found in DB"
+
+    # Verify a CA realisation table was populated (Realisations or BuildTraceV3).
+    real_count = machine.succeed(
+        f"sqlite3 {ca_db} "
+        "\"SELECT COUNT(*) FROM (SELECT 1 FROM sqlite_master WHERE type='table' "
+        "AND name IN ('Realisations','BuildTraceV3'))\""
+    ).strip()
+    assert int(real_count) > 0, "no CA realisation table found"
+
+    # Backdate both so --keep-recent doesn't pin them.
+    machine.succeed(
+        f"sqlite3 {ca_db} "
+        f"\"UPDATE ValidPaths SET registrationTime = 1 "
+        f"WHERE path IN ('{ca_drv}', '{ca_out}')\""
+    )
+
+    # Root the output only; drv should survive via realisation edges.
+    machine.succeed(f"nix-store --add-root /tmp/ca-out-root --indirect -r {ca_out}")
+    machine.succeed("systemctl start fast-nix-gc.service")
+    machine.succeed(f"test -e {ca_out}")
+    machine.succeed(f"test -e {ca_drv}")
+
+    # Now root only the drv; output should survive.
+    machine.succeed(
+        "rm /tmp/ca-out-root",
+        f"ln -sf {ca_drv} /nix/var/nix/gcroots/ca-drv-root",
+    )
+    machine.succeed("systemctl start fast-nix-gc.service")
+    machine.succeed(f"test -e {ca_drv}")
+    machine.succeed(f"test -e {ca_out}")
+    machine.succeed("rm -f /nix/var/nix/gcroots/ca-drv-root")
+
+    # --- BuildTraceV3 (nix from git / unreleased) ---
+    # Use nix-from-git to build a second CA derivation; it populates
+    # BuildTraceV3 instead of Realisations.
+    machine.succeed(
+        "cat > /tmp/ca-test2.nix <<'EOF'\n"
+        "derivation {\n"
+        '  name = "ca-test2";\n'
+        '  system = "${pkgs.system}";\n'
+        '  builder = "/bin/sh";\n'
+        '  args = ["-c" "echo hello2 > $out"];\n'
+        "  __contentAddressed = true;\n"
+        '  outputHashMode = "recursive";\n'
+        '  outputHashAlgo = "sha256";\n'
+        "}\nEOF"
+    )
+    # Use --store local to bypass the system daemon (which is Nix 2.34
+    # and would populate Realisations instead of BuildTraceV3).
+    ca_out2 = machine.succeed(
+        "${pkgs.nixVersions.git}/bin/nix-build --store local"
+        ' --option experimental-features "nix-command ca-derivations"'
+        " --no-out-link /tmp/ca-test2.nix"
+    ).strip()
+
+    ca_drv2 = machine.succeed(
+        f"sqlite3 {ca_db} "
+        f"\"SELECT path FROM ValidPaths WHERE path LIKE '%ca-test2.drv'\""
+    ).strip()
+    assert ca_drv2, "ca-test2 drv not found in DB"
+
+    # Verify BuildTraceV3 was populated.
+    # BuildTraceV3.drvPath stores the basename (no /nix/store/ prefix).
+    ca_drv2_base = ca_drv2.split("/")[-1]
+    bt_count = int(machine.succeed(
+        f"sqlite3 {ca_db} "
+        f"\"SELECT COUNT(*) FROM BuildTraceV3 WHERE drvPath = '{ca_drv2_base}'\""
+    ).strip())
+    assert bt_count > 0, f"BuildTraceV3 has no entry for {ca_drv2_base}"
+
+    machine.succeed(
+        f"sqlite3 {ca_db} "
+        f"\"UPDATE ValidPaths SET registrationTime = 1 "
+        f"WHERE path IN ('{ca_drv2}', '{ca_out2}')\""
+    )
+
+    # Root output; drv should survive via BuildTraceV3.
+    machine.succeed(f"ln -sf {ca_out2} /nix/var/nix/gcroots/ca-out2-root")
+    machine.succeed("systemctl start fast-nix-gc.service")
+    machine.succeed(f"test -e {ca_out2}")
+    machine.succeed(f"test -e {ca_drv2}")
+
+    # Root drv; output should survive via BuildTraceV3.
+    machine.succeed(
+        "rm /nix/var/nix/gcroots/ca-out2-root",
+        f"ln -sf {ca_drv2} /nix/var/nix/gcroots/ca-drv2-root",
+    )
+    machine.succeed("systemctl start fast-nix-gc.service")
+    machine.succeed(f"test -e {ca_drv2}")
+    machine.succeed(f"test -e {ca_out2}")
+    machine.succeed("rm -f /nix/var/nix/gcroots/ca-drv2-root")
 
     # Create a dead store path: add a file with no roots.
     machine.succeed("echo gc-victim > /tmp/gc-dead")


### PR DESCRIPTION
When ca-derivations is enabled, Nix records drv↔output mappings in the BuildTraceV3 table instead of (or in addition to) DerivationOutputs. Without querying this table, fast-nix-gc would miss these edges when keep-derivations or keep-outputs is set, potentially collecting CA outputs whose derivers are alive or vice versa.

Add bidirectional edges from BuildTraceV3 to the in-memory reference graph, mirroring what Nix's queryPartialDerivationOutputMap does for the GC. The table is only queried when it exists (it's created lazily by Nix when the ca-derivations experimental feature is first used).

Closes #23