### PR TITLE
Add tests for GC/optimiser error paths, fix rmdir on read-only trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 result
 /.direnv
+/mutants.out*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "log",
  "nix",
  "rusqlite",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -11,3 +11,6 @@ foldhash.workspace = true
 harmonia-store-core.workspace = true
 nix.workspace = true
 log.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -385,3 +385,309 @@ impl StoreGraph {
         alive
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const H1: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const H2: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const H3: &str = "cccccccccccccccccccccccccccccccc";
+
+    struct TestDb {
+        #[allow(dead_code)] // keep tempdir alive
+        dir: tempfile::TempDir,
+        db: NixDb,
+    }
+
+    fn full(name: &str) -> String {
+        format!("/nix/store/{name}")
+    }
+
+    fn setup() -> TestDb {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state");
+        std::fs::create_dir_all(state.join("db")).unwrap();
+        let conn = Connection::open(state.join("db/db.sqlite")).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE ValidPaths (
+                 id integer primary key autoincrement not null,
+                 path text unique not null,
+                 hash text not null,
+                 registrationTime integer not null,
+                 deriver text,
+                 narSize integer
+             );
+             CREATE TABLE Refs (
+                 referrer integer not null,
+                 reference integer not null,
+                 primary key (referrer, reference),
+                 foreign key (reference) references ValidPaths(id) on delete restrict
+             );
+             CREATE TABLE DerivationOutputs (
+                 drv integer not null,
+                 id text not null,
+                 path text not null,
+                 primary key (drv, id)
+             );",
+        )
+        .unwrap();
+        drop(conn);
+        let mut db = NixDb::open(Path::new("/nix/store"), &state).unwrap();
+        // Pin settings; NixDb::open reads them from the host's nix.conf.
+        db.keep_derivations = false;
+        db.keep_outputs = false;
+        TestDb { dir, db }
+    }
+
+    fn add_path(db: &NixDb, name: &str, nar_size: i64, reg_time: i64) -> i64 {
+        db.conn
+            .execute(
+                "INSERT INTO ValidPaths (path, hash, registrationTime, narSize) \
+                 VALUES (?, 'sha256:x', ?, ?)",
+                rusqlite::params![full(name), reg_time, nar_size],
+            )
+            .unwrap();
+        db.conn.last_insert_rowid()
+    }
+
+    fn add_ref(db: &NixDb, referrer: i64, reference: i64) {
+        db.conn
+            .execute(
+                "INSERT INTO Refs (referrer, reference) VALUES (?, ?)",
+                rusqlite::params![referrer, reference],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn has_table_checks_existence() {
+        let t = setup();
+        assert!(NixDb::has_table(&t.db.conn, "ValidPaths").unwrap());
+        assert!(!NixDb::has_table(&t.db.conn, "NoSuchTable").unwrap());
+    }
+
+    #[test]
+    fn load_graph_builds_csr() {
+        let t = setup();
+        let a = add_path(&t.db, &format!("{H1}-a"), 100, 1000);
+        let b = add_path(&t.db, &format!("{H2}-b"), 200, 2000);
+        let c = add_path(&t.db, &format!("{H3}-c"), 300, 3000);
+        // Two edges from one node exercise the CSR cursor advance.
+        add_ref(&t.db, a, b);
+        add_ref(&t.db, a, c);
+
+        let g = t.db.load_graph().unwrap();
+        assert_eq!(g.len(), 3);
+        assert!(!g.is_empty());
+        let ia = g
+            .paths
+            .iter()
+            .position(|p| p == &full(&format!("{H1}-a")))
+            .unwrap();
+        let ib = g
+            .paths
+            .iter()
+            .position(|p| p == &full(&format!("{H2}-b")))
+            .unwrap();
+        let ic = g
+            .paths
+            .iter()
+            .position(|p| p == &full(&format!("{H3}-c")))
+            .unwrap();
+        assert_eq!(g.nar_sizes[ia], 100);
+        assert_eq!(g.registration_times[ic], 3000);
+        let mut refs_a = g.refs(ia as u32).to_vec();
+        refs_a.sort();
+        let mut expected = vec![ib as u32, ic as u32];
+        expected.sort();
+        assert_eq!(refs_a, expected);
+        assert!(g.refs(ib as u32).is_empty());
+        assert!(g.refs(ic as u32).is_empty());
+    }
+
+    #[test]
+    fn empty_graph() {
+        let t = setup();
+        let g = t.db.load_graph().unwrap();
+        assert_eq!(g.len(), 0);
+        assert!(g.is_empty());
+    }
+
+    #[test]
+    fn store_dir_typed_uses_configured_dir() {
+        let t = setup();
+        // Re-open with a non-default store dir; the typed view must not
+        // fall back to /nix/store.
+        let db = NixDb::open(Path::new("/custom/store"), &t.db.state_dir).unwrap();
+        assert_eq!(db.store_dir_typed().unwrap().to_string(), "/custom/store");
+    }
+
+    #[test]
+    fn load_graph_ignores_edges_with_unknown_ids() {
+        let t = setup();
+        let a = add_path(&t.db, &format!("{H1}-a"), 100, 1000);
+        // Dangling edges must be dropped, not crash or corrupt the CSR.
+        // FK enforcement default varies by SQLite build; this test wants
+        // the corrupt rows.
+        t.db.conn
+            .pragma_update(None, "foreign_keys", "OFF")
+            .unwrap();
+        t.db.conn
+            .execute_batch(&format!("INSERT INTO Refs VALUES ({a}, 9999), (9999, {a})"))
+            .unwrap();
+        let g = t.db.load_graph().unwrap();
+        assert!(g.refs(0).is_empty());
+    }
+
+    #[test]
+    fn load_graph_keep_derivations_adds_output_to_drv_edge() {
+        let t = setup();
+        let mut db = t.db;
+        let drv = add_path(&db, &format!("{H1}-pkg.drv"), 10, 1000);
+        let out = add_path(&db, &format!("{H2}-pkg"), 100, 1000);
+        db.conn
+            .execute(
+                "UPDATE ValidPaths SET deriver = ? WHERE id = ?",
+                rusqlite::params![full(&format!("{H1}-pkg.drv")), out],
+            )
+            .unwrap();
+        let _ = drv;
+
+        db.keep_derivations = true;
+        let g = db.load_graph().unwrap();
+        let iout = g.paths.iter().position(|p| p.ends_with("-pkg")).unwrap() as u32;
+        let idrv = g.paths.iter().position(|p| p.ends_with(".drv")).unwrap() as u32;
+        assert_eq!(g.refs(iout), &[idrv]);
+        assert!(g.refs(idrv).is_empty());
+
+        // keep-outputs adds the reverse edge.
+        db.keep_outputs = true;
+        let g = db.load_graph().unwrap();
+        assert_eq!(g.refs(idrv), &[iout]);
+    }
+
+    #[test]
+    fn load_graph_build_trace_edges() {
+        let t = setup();
+        let mut db = t.db;
+        let drv_base = format!("{H1}-pkg.drv");
+        add_path(&db, &drv_base, 10, 1000);
+        add_path(&db, &format!("{H2}-pkg"), 100, 1000);
+        db.conn
+            .execute_batch(&format!(
+                "CREATE TABLE BuildTraceV3 (
+                     id integer primary key autoincrement not null,
+                     drvPath text not null,
+                     outputName text not null,
+                     outputPath text not null,
+                     signatures text
+                 );
+                 INSERT INTO BuildTraceV3 (drvPath, outputName, outputPath)
+                 VALUES ('{drv_base}', 'out', '{}');",
+                full(&format!("{H2}-pkg"))
+            ))
+            .unwrap();
+
+        db.keep_derivations = true;
+        let g = db.load_graph().unwrap();
+        let iout = g.paths.iter().position(|p| p.ends_with("-pkg")).unwrap() as u32;
+        let idrv = g.paths.iter().position(|p| p.ends_with(".drv")).unwrap() as u32;
+        assert_eq!(g.refs(iout), &[idrv]);
+
+        db.keep_derivations = false;
+        db.keep_outputs = true;
+        let g = db.load_graph().unwrap();
+        assert_eq!(g.refs(idrv), &[iout]);
+    }
+
+    #[test]
+    fn valid_paths_and_typed_variants() {
+        let t = setup();
+        add_path(&t.db, &format!("{H1}-a"), 1, 1);
+        add_path(&t.db, &format!("{H2}-b"), 1, 1);
+
+        let mut paths = t.db.valid_paths().unwrap();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![full(&format!("{H1}-a")), full(&format!("{H2}-b"))]
+        );
+
+        let sd = t.db.store_dir_typed().unwrap();
+        assert_eq!(sd.to_string(), "/nix/store");
+
+        let sps = t.db.valid_store_paths().unwrap();
+        assert_eq!(sps.len(), 2);
+        let names: Vec<_> = sps.iter().map(|p| p.to_string()).collect();
+        assert!(names.iter().any(|n| n.ends_with("-a")), "{names:?}");
+    }
+
+    #[test]
+    fn is_valid_path_checks_db() {
+        let t = setup();
+        add_path(&t.db, &format!("{H1}-a"), 1, 1);
+        assert!(t.db.is_valid_path(&full(&format!("{H1}-a"))).unwrap());
+        assert!(!t.db.is_valid_path(&full(&format!("{H2}-b"))).unwrap());
+    }
+
+    #[test]
+    fn invalidate_paths_handles_ref_cycles() {
+        let t = setup();
+        let a = add_path(&t.db, &format!("{H1}-a"), 1, 1);
+        let b = add_path(&t.db, &format!("{H2}-b"), 1, 1);
+        add_path(&t.db, &format!("{H3}-c"), 1, 1);
+        // Cycle between the two dead paths; FK on delete restrict would
+        // reject row-by-row deletion.
+        add_ref(&t.db, a, b);
+        add_ref(&t.db, b, a);
+
+        let dead = [full(&format!("{H1}-a")), full(&format!("{H2}-b"))];
+        t.db.invalidate_paths(dead.iter().map(|s| s.as_str()))
+            .unwrap();
+
+        assert_eq!(t.db.valid_paths().unwrap(), vec![full(&format!("{H3}-c"))]);
+        let refs: i64 =
+            t.db.conn
+                .query_row("SELECT COUNT(*) FROM Refs", [], |r| r.get(0))
+                .unwrap();
+        assert_eq!(refs, 0);
+    }
+
+    #[test]
+    fn basename_index_lookups() {
+        let t = setup();
+        add_path(&t.db, &format!("{H1}-a"), 1, 1);
+        add_path(&t.db, &format!("{H2}-b"), 1, 1);
+        add_path(&t.db, &format!("{H3}-c"), 1, 1);
+        let g = t.db.load_graph().unwrap();
+        let bidx = BasenameIndex::new(&g);
+
+        let ic = g.paths.iter().position(|p| p.ends_with("-c")).unwrap() as u32;
+        assert_eq!(bidx.idx_of(&full(&format!("{H3}-c"))), Some(ic));
+        assert_eq!(bidx.idx_of_basename(&format!("{H3}-c")), Some(ic));
+        assert_eq!(bidx.idx_of("/elsewhere/x"), None);
+        assert_eq!(bidx.idx_of_basename("nope"), None);
+    }
+
+    #[test]
+    fn compute_closure_marks_reachable_only() {
+        let t = setup();
+        let a = add_path(&t.db, &format!("{H1}-a"), 1, 1);
+        let b = add_path(&t.db, &format!("{H2}-b"), 1, 1);
+        let c = add_path(&t.db, &format!("{H3}-c"), 1, 1);
+        add_ref(&t.db, a, b);
+        // Cycle must terminate.
+        add_ref(&t.db, b, a);
+        let _ = c;
+
+        let g = t.db.load_graph().unwrap();
+        let ia = g.paths.iter().position(|p| p.ends_with("-a")).unwrap() as u32;
+        let ic = g.paths.iter().position(|p| p.ends_with("-c")).unwrap();
+        // Duplicate roots must not double-visit.
+        let alive = g.compute_closure(&[ia, ia]);
+        assert_eq!(alive.len(), 3);
+        assert_eq!(alive.iter().filter(|&&x| x).count(), 2);
+        assert!(!alive[ic]);
+    }
+}

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -50,7 +50,10 @@ fn delete_store_path(real_path: &Path) -> Result<u64> {
         }
         if entry.file_type().is_dir() {
             if fs::remove_dir(p).is_err() {
-                let _ = fs::set_permissions(p, fs::Permissions::from_mode(0o755));
+                // rmdir needs write permission on the parent, not on p.
+                if let Some(parent) = p.parent() {
+                    let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o755));
+                }
                 let _ = fs::remove_dir(p);
             }
         } else if fs::remove_file(p).is_err() {
@@ -182,7 +185,8 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         for entry in entries.flatten() {
             let raw = entry.file_name();
             let name = raw.to_string_lossy();
-            if name == "." || name == ".." || name == ".links" {
+            // read_dir never yields "." or "..".
+            if name == ".links" {
                 continue;
             }
             if bidx.idx_of_basename(name.as_ref()).is_none()
@@ -428,4 +432,82 @@ fn clean_links(links_dir: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn delete_store_path_missing_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(delete_store_path(&tmp.path().join("gone")).unwrap(), 0);
+    }
+
+    #[test]
+    fn delete_store_path_other_stat_errors_propagate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, b"x").unwrap();
+        // ENOTDIR, not ENOENT: must not be treated as "already gone".
+        assert!(delete_store_path(&f.join("sub")).is_err());
+    }
+
+    #[test]
+    fn delete_store_path_file_reports_disk_blocks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("file");
+        fs::write(&f, vec![1u8; 5000]).unwrap();
+        let expected = fs::symlink_metadata(&f).unwrap().blocks() * 512;
+        assert!(expected > 0);
+        assert_eq!(delete_store_path(&f).unwrap(), expected);
+        assert!(!f.exists());
+    }
+
+    #[test]
+    fn delete_store_path_removes_readonly_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("pkg");
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        fs::write(dir.join("sub/file"), vec![1u8; 5000]).unwrap();
+        let mut expected = 0;
+        for e in walkdir::WalkDir::new(&dir) {
+            expected += e.unwrap().metadata().unwrap().blocks() * 512;
+        }
+        // Store paths are read-only on disk.
+        fs::set_permissions(dir.join("sub/file"), fs::Permissions::from_mode(0o444)).unwrap();
+        fs::set_permissions(dir.join("sub"), fs::Permissions::from_mode(0o555)).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        assert_eq!(delete_store_path(&dir).unwrap(), expected);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn try_lock_dir_none_while_held() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = try_lock_dir(tmp.path()).expect("unheld dir is lockable");
+        assert!(try_lock_dir(tmp.path()).is_none(), "held dir must not lock");
+        drop(lock);
+    }
+
+    #[test]
+    fn clean_links_removes_only_unreferenced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let links = tmp.path().join(".links");
+        fs::create_dir_all(&links).unwrap();
+        let dead = links.join("dead");
+        fs::write(&dead, b"unreferenced").unwrap();
+        let shared = links.join("shared");
+        fs::write(&shared, b"referenced").unwrap();
+        fs::hard_link(&shared, tmp.path().join("user")).unwrap();
+
+        clean_links(&links).unwrap();
+
+        assert!(!dead.exists());
+        assert!(shared.exists());
+        // Missing .links dir is not an error.
+        clean_links(&tmp.path().join("nope")).unwrap();
+    }
 }

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -189,10 +189,11 @@ fn scan_blob_for_store_paths(blob: &str, store_prefix: &str, unchecked: &mut Has
             .find(|c: char| !is_store_path_char(c))
             .map(|e| after + e)
             .unwrap_or(blob.len());
-        if end > after {
-            add_unchecked(store_prefix, &blob[abs..end], unchecked);
-        }
-        search_from = end.max(abs + 1);
+        // A bare prefix (end == after) is rejected by add_unchecked's
+        // basename validation, no need to special-case it.
+        add_unchecked(store_prefix, &blob[abs..end], unchecked);
+        // end >= after > abs, so progress is guaranteed.
+        search_from = end;
     }
 }
 
@@ -279,6 +280,32 @@ mod runtime_roots {
             "/proc/sys/kernel/poweroff_cmd",
         ] {
             read_file_root(Path::new(f), store_prefix, unchecked);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn read_file_root_trims_and_extracts() {
+            let tmp = tempfile::tempdir().unwrap();
+            let f = tmp.path().join("modprobe");
+            let sp = "/nix/store/00000000000000000000000000000000-modprobe";
+            fs::write(&f, format!("{sp}/bin/modprobe\n")).unwrap();
+            let mut set = HashSet::default();
+            read_file_root(&f, "/nix/store", &mut set);
+            assert!(set.contains(sp), "{set:?}");
+        }
+
+        #[test]
+        fn read_file_root_ignores_non_store_paths() {
+            let tmp = tempfile::tempdir().unwrap();
+            let f = tmp.path().join("modprobe");
+            fs::write(&f, "/sbin/modprobe\n").unwrap();
+            let mut set = HashSet::default();
+            read_file_root(&f, "/nix/store", &mut set);
+            assert!(set.is_empty());
         }
     }
 }
@@ -645,4 +672,115 @@ pub fn find_temp_roots(state_dir: &Path) -> Result<HashSet<String>> {
     }
 
     Ok(roots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HASH: &str = "abcdefghijklmnopqrstuvwxyz012345"; // 32 chars
+
+    #[test]
+    fn store_path_basename_grammar() {
+        assert!(is_store_path_basename(&format!("{HASH}-foo")));
+        assert!(is_store_path_basename(&format!("{HASH}-foo-1.2+x_y?z=")));
+        // Too short / missing dash at position 32.
+        assert!(!is_store_path_basename("short"));
+        assert!(!is_store_path_basename(&format!("{HASH}xfoo")));
+        // Uppercase or invalid chars in hash part.
+        assert!(!is_store_path_basename(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345-foo"
+        ));
+        // Invalid char in name part: both halves must hold.
+        assert!(!is_store_path_basename(&format!("{HASH}-foo bar")));
+        // .links and .. must never look like store paths.
+        assert!(!is_store_path_basename(".links"));
+        assert!(!is_store_path_basename(".."));
+    }
+
+    #[test]
+    fn is_in_store_requires_separator() {
+        assert!(is_in_store("/nix/store", "/nix/store/abc"));
+        assert!(!is_in_store("/nix/store", "/nix/store"));
+        assert!(!is_in_store("/nix/store", "/nix/store-other/abc"));
+        assert!(!is_in_store("/nix/store", "/somewhere/else"));
+    }
+
+    #[test]
+    fn extract_store_path_takes_first_component() {
+        let sp = format!("/nix/store/{HASH}-foo");
+        assert_eq!(
+            extract_store_path("/nix/store", &format!("{sp}/bin/bar")),
+            Some(sp.clone())
+        );
+        assert_eq!(extract_store_path("/nix/store", &sp), Some(sp));
+        assert_eq!(
+            extract_store_path("/nix/store", "/nix/store/.links/x"),
+            None
+        );
+        assert_eq!(extract_store_path("/nix/store", "/nix/store"), None);
+    }
+
+    #[test]
+    fn scan_blob_finds_embedded_store_paths() {
+        let sp1 = format!("/nix/store/{HASH}-foo");
+        let sp2 = format!("/nix/store/{HASH}-bar");
+        // Paths embedded mid-blob with trailing junk, and one ending the blob.
+        let blob = format!("PATH={sp1}/bin:other LD={sp2}");
+        let mut set = HashSet::default();
+        scan_blob_for_store_paths(&blob, "/nix/store", &mut set);
+        assert_eq!(set.len(), 2, "{set:?}");
+        assert!(set.contains(&sp1));
+        assert!(set.contains(&sp2));
+    }
+
+    #[test]
+    fn scan_blob_ignores_bare_prefix() {
+        let mut set = HashSet::default();
+        scan_blob_for_store_paths("x /nix/store/ y /nix/store::", "/nix/store", &mut set);
+        assert!(set.is_empty(), "{set:?}");
+    }
+
+    #[test]
+    fn temp_roots_reads_locked_skips_stale_and_junk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("temproots");
+        fs::create_dir_all(&dir).unwrap();
+
+        let sp1 = format!("/nix/store/{HASH}-live1");
+        let sp2 = format!("/nix/store/{HASH}-live2");
+        // Live file: owner (us) holds the write lock; trailing segment
+        // without NUL is a partial write and must be dropped.
+        let live = dir.join("12345");
+        fs::write(&live, format!("{sp1}\0{sp2}\0partial")).unwrap();
+        let f = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&live)
+            .unwrap();
+        let _lock =
+            nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockExclusiveNonblock).unwrap();
+
+        // Stale file: no lock held, must be removed and ignored.
+        let stale = dir.join("999");
+        fs::write(&stale, format!("/nix/store/{HASH}-stale\0")).unwrap();
+
+        // Hidden and non-PID files are not temp roots.
+        fs::write(dir.join(".keep"), b"junk").unwrap();
+        fs::write(dir.join("notapid"), format!("/nix/store/{HASH}-junk\0")).unwrap();
+
+        let roots = find_temp_roots(tmp.path()).unwrap();
+        assert!(roots.contains(&sp1));
+        assert!(roots.contains(&sp2));
+        assert_eq!(roots.len(), 2, "{roots:?}");
+        assert!(!stale.exists(), "stale temp roots file removed");
+        assert!(dir.join(".keep").exists());
+        assert!(dir.join("notapid").exists());
+    }
+
+    #[test]
+    fn temp_roots_missing_dir_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(find_temp_roots(tmp.path()).unwrap().is_empty());
+    }
 }

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -40,11 +40,28 @@ fn fake_hash(name: &str) -> String {
 
 impl TestStore {
     fn new() -> Self {
+        Self::new_inner(false)
+    }
+
+    /// Store dir is a symlink to the real directory, like /nix/store on
+    /// installs with a relocated store. The kernel reports canonical
+    /// paths for fds, the DB stores logical ones.
+    fn new_symlinked() -> Self {
+        Self::new_inner(true)
+    }
+
+    fn new_inner(symlink_store: bool) -> Self {
         let dir = tempfile::tempdir().unwrap();
         let store_dir = dir.path().join("store");
         let state_dir = dir.path().join("state");
 
-        fs::create_dir_all(&store_dir).unwrap();
+        if symlink_store {
+            let real = dir.path().join("store-real");
+            fs::create_dir_all(&real).unwrap();
+            std::os::unix::fs::symlink(&real, &store_dir).unwrap();
+        } else {
+            fs::create_dir_all(&store_dir).unwrap();
+        }
         for d in ["db", "gcroots", "profiles", "temproots"] {
             fs::create_dir_all(state_dir.join(d)).unwrap();
         }
@@ -461,6 +478,51 @@ fn gc_keeps_runtime_roots_from_open_fd() {
     // Inherit an fd into the child so the path shows up in the GC's
     // own /proc/<pid>/fd. Sandboxes can't always inspect other PIDs.
     let f = fs::File::open(held.path.join("file")).unwrap();
+    let raw_fd = f.as_raw_fd();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_fast-nix-gc"));
+    cmd.arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir);
+    unsafe {
+        cmd.pre_exec(move || {
+            use nix::fcntl::{F_GETFD, F_SETFD, FdFlag, fcntl};
+            use std::os::fd::BorrowedFd;
+            let fd = BorrowedFd::borrow_raw(raw_fd);
+            if let Ok(flags) = fcntl(fd, F_GETFD) {
+                let mut flags = FdFlag::from_bits_truncate(flags);
+                flags.remove(FdFlag::FD_CLOEXEC);
+                let _ = fcntl(fd, F_SETFD(flags));
+            }
+            Ok(())
+        });
+    }
+    let out = cmd.output().unwrap();
+    drop(f);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(held.path.exists() && store.in_db(&held));
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_rebases_canonical_runtime_roots_to_logical_store() {
+    use std::os::unix::process::CommandExt;
+    let store = TestStore::new_symlinked();
+
+    let held = store.add_path("held", 100);
+    let trash = store.add_path("trash", 100);
+
+    // Open via the canonical (symlink-resolved) path; /proc/<pid>/fd will
+    // report that path, which must be rebased to the logical store prefix
+    // before DB validation.
+    let canon = fs::canonicalize(held.path.join("file")).unwrap();
+    assert_ne!(canon, held.path.join("file"));
+    let f = fs::File::open(&canon).unwrap();
     let raw_fd = f.as_raw_fd();
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_fast-nix-gc"));
     cmd.arg("--store-dir")

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -237,9 +237,72 @@ fn gc_dry_run_does_not_delete() {
 
     assert!(dead.path.exists() && store.in_db(&dead));
     let stdout = String::from_utf8_lossy(&out.stdout);
+    // narSize of "dead" is 500; the estimate must be summed correctly.
     assert!(
-        stdout.contains("1 store paths would be deleted"),
+        stdout.contains("1 store paths would be deleted (~500 bytes)"),
         "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn gc_removes_unlocked_tmp_dir() {
+    let store = TestStore::new();
+
+    let tmp = store.store_dir.join("tmp-build-9999");
+    fs::create_dir_all(&tmp).unwrap();
+    fs::write(tmp.join("left-over"), "data").unwrap();
+
+    let out = store.run_gc_ok(&[]);
+
+    assert!(!tmp.exists(), "unlocked tmp dir is garbage");
+    // No shared links exist, so no savings line must be logged.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!stderr.contains("currently saving"), "stderr: {stderr}");
+}
+
+#[test]
+fn gc_dry_run_counts_unknown_on_disk() {
+    let store = TestStore::new();
+
+    let unknown = store
+        .store_dir
+        .join(format!("{}-unknown", fake_hash("unknown")));
+    fs::create_dir_all(&unknown).unwrap();
+
+    let out = store.run_gc_ok(&["--dry-run"]);
+
+    assert!(unknown.exists());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("1 store paths would be deleted (~0 bytes)"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn gc_cleans_unused_links_only_when_not_dry_run() {
+    let store = TestStore::new();
+
+    let links = store.store_dir.join(".links");
+    let dead_link = links.join("deadlink");
+    fs::write(&dead_link, "unreferenced").unwrap();
+    let shared_link = links.join("sharedlink");
+    fs::write(&shared_link, "referenced").unwrap();
+    let pkg = store.add_path("linked", 100);
+    store.add_root("linked-root", &pkg);
+    fs::hard_link(&shared_link, pkg.path.join("shared")).unwrap();
+
+    store.run_gc_ok(&["--dry-run"]);
+    assert!(dead_link.exists(), "dry run must not clean links");
+
+    let out = store.run_gc_ok(&[]);
+    assert!(!dead_link.exists(), "unreferenced link removed");
+    assert!(shared_link.exists(), "referenced link kept");
+    // "referenced" is 10 bytes with nlink 2: savings = (2-1)*10.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("currently saving 10 bytes"),
+        "stderr: {stderr}"
     );
 }
 

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -623,6 +623,232 @@ mod tests {
         rusqlite::Connection::open(p).unwrap()
     }
 
+    fn mk_store_path(store: &Path, name: &str, content: &[u8]) -> PathBuf {
+        let p = store.join(name);
+        fs::create_dir_all(&p).unwrap();
+        let f = p.join("data");
+        fs::write(&f, content).unwrap();
+        fs::set_permissions(&f, fs::Permissions::from_mode(0o444)).unwrap();
+        fs::set_permissions(&p, fs::Permissions::from_mode(0o555)).unwrap();
+        p
+    }
+
+    fn mk_db(state: &Path, paths: &[&Path]) {
+        fs::create_dir_all(state.join("db")).unwrap();
+        let conn = rusqlite_open(&state.join("db/db.sqlite"));
+        conn.execute_batch("CREATE TABLE ValidPaths (id INTEGER PRIMARY KEY, path TEXT NOT NULL);")
+            .unwrap();
+        for p in paths {
+            conn.execute(
+                "INSERT INTO ValidPaths (path) VALUES (?)",
+                [p.to_str().unwrap()],
+            )
+            .unwrap();
+        }
+    }
+
+    fn unlock(p: &Path) {
+        fs::set_permissions(p, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    fn run_opts(store: &Path, state: &Path) -> Options {
+        Options {
+            store_dir: store.to_path_buf(),
+            state_dir: state.to_path_buf(),
+            jobs: 1,
+            ..Options::default()
+        }
+    }
+
+    #[test]
+    fn load_link_inodes_missing_dir_is_empty() {
+        let tmp = tempdir().unwrap();
+        let set = load_link_inodes(&tmp.path().join("nope")).unwrap();
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn load_link_inodes_returns_actual_inodes() {
+        let tmp = tempdir().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        fs::write(&a, b"x").unwrap();
+        fs::write(&b, b"y").unwrap();
+        let set = load_link_inodes(tmp.path()).unwrap();
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&fs::metadata(&a).unwrap().ino()));
+        assert!(set.contains(&fs::metadata(&b).unwrap().ino()));
+    }
+
+    #[test]
+    fn rand_suffix_is_unique_per_call() {
+        assert_ne!(rand_suffix(), rand_suffix());
+    }
+
+    #[test]
+    fn errno_helpers_match_libc_values() {
+        assert_eq!(libc_enospc(), nix::errno::Errno::ENOSPC as i32);
+        assert_eq!(libc_emlink(), nix::errno::Errno::EMLINK as i32);
+        assert!(libc_enospc() > 1);
+        assert!(libc_emlink() > 1);
+        assert_ne!(libc_enospc(), libc_emlink());
+    }
+
+    #[test]
+    fn logger_respects_level_filter() {
+        use log::Log as _;
+        let logger = StderrLogger(log::LevelFilter::Info);
+        let info = log::Metadata::builder().level(log::Level::Info).build();
+        let debug = log::Metadata::builder().level(log::Level::Debug).build();
+        assert!(logger.enabled(&info));
+        assert!(!logger.enabled(&debug));
+    }
+
+    const CONTENT: &[u8] = b"hello world hello world hello world\n";
+
+    async fn run_two_identical(
+        min_size: u64,
+        dry_run: bool,
+    ) -> (Stats, PathBuf, PathBuf, tempfile::TempDir) {
+        let tmp = tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&store).unwrap();
+        let p1 = mk_store_path(&store, "cccccccccccccccccccccccccccccccc-c", CONTENT);
+        let p2 = mk_store_path(&store, "dddddddddddddddddddddddddddddddd-d", CONTENT);
+        mk_db(&state, &[&p1, &p2]);
+        let stats = optimise_store(Options {
+            min_size,
+            dry_run,
+            ..run_opts(&store, &state)
+        })
+        .await
+        .unwrap();
+        unlock(&p1);
+        unlock(&p2);
+        (stats, p1.join("data"), p2.join("data"), tmp)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn min_size_equal_to_len_is_processed() {
+        let (stats, f1, f2, _tmp) = run_two_identical(CONTENT.len() as u64, false).await;
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.files_skipped.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            fs::metadata(&f1).unwrap().ino(),
+            fs::metadata(&f2).unwrap().ino()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn min_size_above_len_is_skipped() {
+        let (stats, f1, f2, _tmp) = run_two_identical(CONTENT.len() as u64 + 1, false).await;
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.files_skipped.load(Ordering::Relaxed), 2);
+        assert_ne!(
+            fs::metadata(&f1).unwrap().ino(),
+            fs::metadata(&f2).unwrap().ino()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dry_run_counts_but_does_not_link() {
+        let (stats, f1, f2, _tmp) = run_two_identical(0, true).await;
+        // .links is empty in dry-run, so both files count as linkable.
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            stats.bytes_freed.load(Ordering::Relaxed),
+            2 * CONTENT.len() as u64
+        );
+        assert_ne!(
+            fs::metadata(&f1).unwrap().ino(),
+            fs::metadata(&f2).unwrap().ino()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restores_parent_perms_and_mtime() {
+        let tmp = tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&store).unwrap();
+        let p1 = mk_store_path(&store, "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk-k", CONTENT);
+        let p2 = mk_store_path(&store, "ffffffffffffffffffffffffffffffff-f", CONTENT);
+        mk_db(&state, &[&p1, &p2]);
+        let stats = optimise_store(run_opts(&store, &state)).await.unwrap();
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 1);
+        // Exactly one dir had its file replaced; that dir must be restored
+        // to mode 0555 with mtime 1.
+        let restored: Vec<_> = [&p1, &p2]
+            .into_iter()
+            .map(|p| fs::metadata(p).unwrap())
+            .filter(|m| m.mtime() == 1)
+            .collect();
+        assert_eq!(restored.len(), 1, "one parent dir restored to mtime 1");
+        assert_eq!(restored[0].permissions().mode() & 0o777, 0o555);
+        unlock(&p1);
+        unlock(&p2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn corrupt_link_with_size_mismatch_is_skipped() {
+        let tmp = tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&store).unwrap();
+        let p1 = mk_store_path(&store, "gggggggggggggggggggggggggggggggg-g", CONTENT);
+        mk_db(&state, &[&p1]);
+        // Pre-create a corrupt .links entry under the file's hash with a
+        // different size.
+        let hash = nar_hash_nix32(&p1.join("data")).await.unwrap();
+        let links = store.join(".links");
+        fs::create_dir_all(&links).unwrap();
+        fs::write(links.join(&hash), b"wrong size").unwrap();
+
+        let stats = optimise_store(run_opts(&store, &state)).await.unwrap();
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 0);
+        assert_ne!(
+            fs::metadata(p1.join("data")).unwrap().ino(),
+            fs::metadata(links.join(&hash)).unwrap().ino()
+        );
+        unlock(&p1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn canonical_file_is_not_counted_as_linked() {
+        let tmp = tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&store).unwrap();
+        let p1 = mk_store_path(&store, "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh-h", CONTENT);
+        mk_db(&state, &[&p1]);
+        let stats = optimise_store(run_opts(&store, &state)).await.unwrap();
+        // Sole file becomes the canonical .links entry (same inode);
+        // nothing is replaced, so the counter must stay 0.
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 0);
+        assert_eq!(store.join(".links").read_dir().unwrap().count(), 1);
+        unlock(&p1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writable_file_is_skipped_as_suspicious() {
+        let tmp = tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&store).unwrap();
+        let p1 = mk_store_path(&store, "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii-i", CONTENT);
+        let p2 = mk_store_path(&store, "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj-j", CONTENT);
+        unlock(&p2);
+        fs::set_permissions(p2.join("data"), fs::Permissions::from_mode(0o644)).unwrap();
+        fs::set_permissions(&p2, fs::Permissions::from_mode(0o555)).unwrap();
+        mk_db(&state, &[&p1, &p2]);
+        let stats = optimise_store(run_opts(&store, &state)).await.unwrap();
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.files_skipped.load(Ordering::Relaxed), 1);
+        unlock(&p1);
+        unlock(&p2);
+    }
+
     #[test]
     fn shared_gc_lock_blocks_exclusive() {
         use nix::fcntl::{Flock, FlockArg};


### PR DESCRIPTION
Apply cargo-mutants to close test gaps.