### PR TITLE
Fix correctness, safety and Nix-compatibility bugs found in review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fast-nix-common",
- "foldhash 0.2.0",
  "harmonia-store-db",
  "log",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,6 @@ harmonia-utils-io            = { git = "https://github.com/nix-community/harmoni
 harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia", rev = "9789e1d0a322360442ff2a2a150f8bd2b9ccf93a" }
 harmonia-store-path-info     = { git = "https://github.com/nix-community/harmonia", rev = "9789e1d0a322360442ff2a2a150f8bd2b9ccf93a" }
 
-[profile.release]
-
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -14,12 +14,11 @@ pub struct NixDb {
     pub real_store_dir: PathBuf,
     pub links_dir: PathBuf,
     /// Mirror of Nix's `keep-derivations` setting (default: true).
-    /// When set, .drv files of alive outputs are kept alive, and alive
-    /// .drv files keep their outputs alive.
+    /// When set, an alive path keeps its deriver (`ValidPaths.deriver`)
+    /// alive.
     pub keep_derivations: bool,
     /// Mirror of Nix's `keep-outputs` setting (default: false).
-    /// When set, outputs of alive derivations are kept alive, and alive
-    /// outputs keep their derivers alive.
+    /// When set, an alive .drv file keeps its outputs alive.
     pub keep_outputs: bool,
 }
 
@@ -162,22 +161,31 @@ impl NixDb {
         // Refs table: direct references between store paths.
         add_edges(&self.conn, "SELECT referrer, reference FROM Refs", &[])?;
 
-        // Edge directions mirror Nix's computeFSClosure (misc.cc), which
-        // the GC calls with includeOutputs = keep-outputs and
-        // includeDerivers = keep-derivations:
-        //   keep-derivations: alive output keeps its drv alive (output→drv)
-        //   keep-outputs:     alive drv keeps its outputs alive (drv→output)
+        // Edge directions mirror exactly what Nix's GC propagates
+        // (gc.cc maybeDeleteReferrersClosure + misc.cc computeFSClosure
+        // with includeOutputs = keep-outputs, includeDerivers =
+        // keep-derivations):
         //
-        // drv↔output mappings come from three places:
-        // - ValidPaths.deriver (all Nix versions; also covers CA outputs of
-        //   Nix ≤2.34, whose Realisations table keys drvPath by content
-        //   hash and so can't be joined against ValidPaths)
-        // - DerivationOutputs (input-addressed)
-        // - BuildTraceV3 (CA/dynamic derivations, Nix ≥2.35): drvPath is a
-        //   store path *basename*, outputPath a full store path. Created
-        //   lazily; skip if absent.
-        let has_build_trace = (self.keep_derivations || self.keep_outputs)
-            && Self::has_table(&self.conn, "BuildTraceV3")?;
+        //   keep-derivations: an alive path keeps `info->deriver` alive.
+        //     Edge output→drv via ValidPaths.deriver ONLY. The referrer
+        //     walk's condition (output of drv with deriver == drv) is a
+        //     subset of this. Nix does NOT pin a drv merely because a
+        //     DerivationOutputs/BuildTraceV3 row maps one of its outputs:
+        //     if the output's deriver is a different (newer) drv, the old
+        //     drv is garbage.
+        //
+        //   keep-outputs: an alive drv keeps its outputs alive.
+        //     Edge drv→output via the drv's output map: DerivationOutputs
+        //     for input-addressed outputs, BuildTraceV3 for CA/dynamic
+        //     outputs (Nix ≥2.35; drvPath is a store path *basename*,
+        //     outputPath a full store path; created lazily, skip if
+        //     absent), plus ValidPaths.deriver. The deriver edge is a
+        //     subset of Nix's relation (deriver == drv implies the path is
+        //     in the drv's output map) and is the only usable drv→output
+        //     mapping for CA outputs of Nix ≤2.34, whose Realisations
+        //     table keys drvPath by content hash and so can't be joined
+        //     against ValidPaths.
+        let has_build_trace = self.keep_outputs && Self::has_table(&self.conn, "BuildTraceV3")?;
         let store_prefix = format!("{}/", self.store_dir.display());
 
         if self.keep_derivations {
@@ -189,24 +197,6 @@ impl NixDb {
                  WHERE v.deriver IS NOT NULL",
                 &[],
             )?;
-            // output → drv via DerivationOutputs (covers outputs whose
-            // deriver column is unset)
-            add_edges(
-                &self.conn,
-                "SELECT o.id, do2.drv FROM ValidPaths o \
-                 JOIN DerivationOutputs do2 ON do2.path = o.path",
-                &[],
-            )?;
-            if has_build_trace {
-                // output → drv via BuildTraceV3
-                add_edges(
-                    &self.conn,
-                    "SELECT o.id, d.id FROM BuildTraceV3 bt \
-                     JOIN ValidPaths o ON o.path = bt.outputPath \
-                     JOIN ValidPaths d ON d.path = ? || bt.drvPath",
-                    &[&store_prefix],
-                )?;
-            }
         }
 
         if self.keep_outputs {
@@ -217,7 +207,8 @@ impl NixDb {
                  JOIN ValidPaths o ON o.path = do2.path",
                 &[],
             )?;
-            // drv → output via ValidPaths.deriver
+            // drv → output via ValidPaths.deriver (covers Realisations-era
+            // CA outputs; see the edge-direction comment above)
             add_edges(
                 &self.conn,
                 "SELECT d.id, v.id FROM ValidPaths v \
@@ -633,7 +624,8 @@ mod tests {
         assert_eq!(g.refs(iout), &[idrv]);
         assert!(g.refs(idrv).is_empty());
 
-        // keep-outputs adds the reverse edge.
+        // keep-outputs: the deriver field alone pins the output (it is
+        // the only drv→output mapping for Realisations-era CA outputs).
         db.keep_outputs = true;
         let g = db.load_graph().unwrap();
         assert_eq!(g.refs(idrv), &[iout]);
@@ -661,12 +653,16 @@ mod tests {
             ))
             .unwrap();
 
+        // keep-derivations pins drvs only via the deriver field; a
+        // BuildTraceV3 row alone must not create an output→drv edge
+        // (the output may have been rebuilt by a newer drv).
         db.keep_derivations = true;
         let g = db.load_graph().unwrap();
         let iout = g.paths.iter().position(|p| p.ends_with("-pkg")).unwrap() as u32;
         let idrv = g.paths.iter().position(|p| p.ends_with(".drv")).unwrap() as u32;
-        assert_eq!(g.refs(iout), &[idrv]);
+        assert!(g.refs(iout).is_empty());
 
+        // keep-outputs pins CA outputs of an alive drv via BuildTraceV3.
         db.keep_derivations = false;
         db.keep_outputs = true;
         let g = db.load_graph().unwrap();

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -269,21 +269,15 @@ impl NixDb {
         })
     }
 
-    /// Return all valid store paths (full paths, e.g. `/nix/store/xxx-foo`).
-    pub fn valid_paths(&self) -> Result<Vec<String>> {
-        let mut stmt = self.conn.prepare("SELECT path FROM ValidPaths")?;
-        let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
-        Ok(rows.collect::<rusqlite::Result<_>>()?)
-    }
-
     /// `StoreDir` view of `store_dir`. Fails if it isn't valid UTF-8.
     pub fn store_dir_typed(&self) -> Result<StoreDir> {
         StoreDir::new(self.store_dir.clone())
             .map_err(|e| anyhow!("{}: {e}", self.store_dir.display()))
     }
 
-    /// Like `valid_paths` but parsed into `StorePath`. Rows that don't parse
-    /// (corrupt DB) are returned as an error rather than silently dropped.
+    /// Return all valid store paths parsed into `StorePath`. Rows that
+    /// don't parse (corrupt DB) are returned as an error rather than
+    /// silently dropped.
     pub fn valid_store_paths(&self) -> Result<Vec<StorePath>> {
         let store_dir = self.store_dir_typed()?;
         let mut stmt = self.conn.prepare("SELECT path FROM ValidPaths")?;
@@ -680,12 +674,17 @@ mod tests {
     }
 
     #[test]
-    fn valid_paths_and_typed_variants() {
+    fn valid_store_paths_and_typed_variants() {
         let t = setup();
         add_path(&t.db, &format!("{H1}-a"), 1, 1);
         add_path(&t.db, &format!("{H2}-b"), 1, 1);
 
-        let mut paths = t.db.valid_paths().unwrap();
+        let mut paths: Vec<String> =
+            t.db.valid_store_paths()
+                .unwrap()
+                .iter()
+                .map(|p| format!("/nix/store/{p}"))
+                .collect();
         paths.sort();
         assert_eq!(
             paths,
@@ -724,7 +723,13 @@ mod tests {
         t.db.invalidate_paths(dead.iter().map(|s| s.as_str()))
             .unwrap();
 
-        assert_eq!(t.db.valid_paths().unwrap(), vec![full(&format!("{H3}-c"))]);
+        let remaining: Vec<String> =
+            t.db.valid_store_paths()
+                .unwrap()
+                .iter()
+                .map(|p| format!("/nix/store/{p}"))
+                .collect();
+        assert_eq!(remaining, vec![full(&format!("{H3}-c"))]);
         let refs: i64 =
             t.db.conn
                 .query_row("SELECT COUNT(*) FROM Refs", [], |r| r.get(0))

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -25,20 +25,34 @@ pub struct NixDb {
 
 impl NixDb {
     pub fn open(store_dir: &Path, state_dir: &Path) -> Result<Self> {
+        Self::open_with_mode(store_dir, state_dir, false)
+    }
+
+    /// Read-only open for dry runs: no journal-mode flip, no write lock,
+    /// works on a read-only filesystem.
+    pub fn open_read_only(store_dir: &Path, state_dir: &Path) -> Result<Self> {
+        Self::open_with_mode(store_dir, state_dir, true)
+    }
+
+    fn open_with_mode(store_dir: &Path, state_dir: &Path, read_only: bool) -> Result<Self> {
         // "/nix/store/" must equal "/nix/store": every prefix comparison
         // against DB paths appends its own '/'. A trailing slash would make
         // the basename index empty and the whole store look dead.
         let store_dir = normalize_dir(store_dir);
         let store_dir = store_dir.as_path();
         let db_path = state_dir.join("db/db.sqlite");
-        let conn = Connection::open_with_flags(
-            &db_path,
-            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )
-        .with_context(|| format!("opening {}", db_path.display()))?;
+        let rw_flag = if read_only {
+            OpenFlags::SQLITE_OPEN_READ_ONLY
+        } else {
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+        };
+        let conn = Connection::open_with_flags(&db_path, rw_flag | OpenFlags::SQLITE_OPEN_NO_MUTEX)
+            .with_context(|| format!("opening {}", db_path.display()))?;
 
-        conn.pragma_update(None, "journal_mode", "WAL")?;
-        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        if !read_only {
+            conn.pragma_update(None, "journal_mode", "WAL")?;
+            conn.pragma_update(None, "synchronous", "NORMAL")?;
+        }
         // Nix's schema relies on FK actions (DerivationOutputs/Refs rows
         // cascade when a ValidPaths row goes away), but SQLite only honors
         // them with the pragma on. Without it every invalidation leaks

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -91,7 +91,17 @@ impl NixDb {
         // Both queries must see the same snapshot, otherwise a path
         // registered between them ends up with missing edges.
         self.conn.execute_batch("BEGIN")?;
+        let result = self.load_graph_in_txn();
+        if result.is_err() {
+            // Leave the connection usable for the caller.
+            self.conn.execute_batch("ROLLBACK").ok();
+        } else {
+            self.conn.execute_batch("COMMIT")?;
+        }
+        result
+    }
 
+    fn load_graph_in_txn(&self) -> Result<StoreGraph> {
         // ids are dense autoincrement, so a Vec works as the id->idx map.
         let max_id: i64 =
             self.conn
@@ -219,7 +229,6 @@ impl NixDb {
             }
         }
 
-        self.conn.execute_batch("COMMIT")?;
 
         let mut ref_offsets = vec![0u32; n + 1];
         for &(from, _) in &edges {

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -232,6 +232,12 @@ impl NixDb {
             }
         }
 
+        // CSR offsets are u32; refuse to build a graph the index type
+        // cannot address instead of silently wrapping.
+        anyhow::ensure!(
+            edges.len() <= u32::MAX as usize,
+            "store has more than 2^32 reference edges"
+        );
 
         let mut ref_offsets = vec![0u32; n + 1];
         for &(from, _) in &edges {

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -411,6 +411,18 @@ impl<'g> BasenameIndex<'g> {
 }
 
 impl StoreGraph {
+    /// Graph with no nodes, used while the real graph is still loading.
+    pub fn empty(store_prefix: String) -> StoreGraph {
+        StoreGraph {
+            paths: Vec::new(),
+            nar_sizes: Vec::new(),
+            registration_times: Vec::new(),
+            ref_offsets: vec![0],
+            ref_targets: Vec::new(),
+            store_prefix,
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.paths.len()
     }

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -25,6 +25,11 @@ pub struct NixDb {
 
 impl NixDb {
     pub fn open(store_dir: &Path, state_dir: &Path) -> Result<Self> {
+        // "/nix/store/" must equal "/nix/store": every prefix comparison
+        // against DB paths appends its own '/'. A trailing slash would make
+        // the basename index empty and the whole store look dead.
+        let store_dir = normalize_dir(store_dir);
+        let store_dir = store_dir.as_path();
         let db_path = state_dir.join("db/db.sqlite");
         let conn = Connection::open_with_flags(
             &db_path,
@@ -298,6 +303,17 @@ impl NixDb {
             }
         }
     }
+}
+
+/// Strip trailing slashes (but keep a bare "/").
+fn normalize_dir(dir: &Path) -> PathBuf {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    let bytes = dir.as_os_str().as_bytes();
+    let mut end = bytes.len();
+    while end > 1 && bytes[end - 1] == b'/' {
+        end -= 1;
+    }
+    PathBuf::from(std::ffi::OsString::from_vec(bytes[..end].to_vec()))
 }
 
 /// In-memory snapshot of the store reference graph in CSR layout.

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -39,6 +39,14 @@ impl NixDb {
 
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
+        // Nix's schema relies on FK actions (DerivationOutputs/Refs rows
+        // cascade when a ValidPaths row goes away), but SQLite only honors
+        // them with the pragma on. Without it every invalidation leaks
+        // orphaned DerivationOutputs rows.
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        // nix-daemon may hold short write locks; fail with SQLITE_BUSY only
+        // after a grace period, like Nix's busy handler.
+        conn.busy_timeout(std::time::Duration::from_secs(60))?;
 
         Ok(NixDb {
             conn,
@@ -288,6 +296,22 @@ impl NixDb {
                 "DELETE FROM Refs WHERE referrer IN (SELECT id FROM DeadPaths) \
                  OR reference IN (SELECT id FROM DeadPaths)",
             )?;
+            // Same for the CA realisations of Nix ≤2.34:
+            // RealisationsRefs.realisationReference is ON DELETE RESTRICT,
+            // and our bulk DELETE is unordered (Nix avoids the constraint
+            // by deleting one path at a time in topological order).
+            if Self::has_table(&self.conn, "Realisations")? {
+                self.conn.execute_batch(
+                    "DELETE FROM RealisationsRefs WHERE referrer IN \
+                         (SELECT id FROM Realisations WHERE outputPath IN \
+                             (SELECT id FROM DeadPaths)) \
+                     OR realisationReference IN \
+                         (SELECT id FROM Realisations WHERE outputPath IN \
+                             (SELECT id FROM DeadPaths)); \
+                     DELETE FROM Realisations WHERE outputPath IN \
+                         (SELECT id FROM DeadPaths)",
+                )?;
+            }
             self.conn
                 .execute_batch("DELETE FROM ValidPaths WHERE id IN (SELECT id FROM DeadPaths)")?;
             Ok(())
@@ -444,7 +468,8 @@ mod tests {
                  drv integer not null,
                  id text not null,
                  path text not null,
-                 primary key (drv, id)
+                 primary key (drv, id),
+                 foreign key (drv) references ValidPaths(id) on delete cascade
              );",
         )
         .unwrap();
@@ -668,6 +693,76 @@ mod tests {
                 .query_row("SELECT COUNT(*) FROM Refs", [], |r| r.get(0))
                 .unwrap();
         assert_eq!(refs, 0);
+    }
+
+    #[test]
+    fn invalidate_paths_cascades_derivation_outputs() {
+        let t = setup();
+        let drv = add_path(&t.db, &format!("{H1}-pkg.drv"), 1, 1);
+        let out = add_path(&t.db, &format!("{H2}-pkg"), 1, 1);
+        t.db.conn
+            .execute(
+                "INSERT INTO DerivationOutputs (drv, id, path) VALUES (?, 'out', ?)",
+                rusqlite::params![drv, full(&format!("{H2}-pkg"))],
+            )
+            .unwrap();
+        let _ = out;
+
+        let dead = [full(&format!("{H1}-pkg.drv"))];
+        t.db.invalidate_paths(dead.iter().map(|s| s.as_str()))
+            .unwrap();
+
+        let n: i64 =
+            t.db.conn
+                .query_row("SELECT COUNT(*) FROM DerivationOutputs", [], |r| r.get(0))
+                .unwrap();
+        assert_eq!(n, 0, "DerivationOutputs row orphaned");
+    }
+
+    #[test]
+    fn invalidate_paths_clears_realisations_with_restrict_fk() {
+        // Nix ≤2.34 CA schema: RealisationsRefs.realisationReference is ON
+        // DELETE RESTRICT. Bulk-deleting two dead paths whose realisations
+        // reference each other must not trip the constraint.
+        let t = setup();
+        t.db.conn
+            .execute_batch(
+                "CREATE TABLE Realisations (
+                     id integer primary key autoincrement not null,
+                     drvPath text not null,
+                     outputName text not null,
+                     outputPath integer not null references ValidPaths(id) on delete cascade,
+                     signatures text
+                 );
+                 CREATE TABLE RealisationsRefs (
+                     referrer integer not null,
+                     realisationReference integer,
+                     foreign key (referrer) references Realisations(id) on delete cascade,
+                     foreign key (realisationReference) references Realisations(id) on delete restrict
+                 );",
+            )
+            .unwrap();
+        let a = add_path(&t.db, &format!("{H1}-a"), 1, 1);
+        let b = add_path(&t.db, &format!("{H2}-b"), 1, 1);
+        t.db.conn
+            .execute_batch(&format!(
+                "INSERT INTO Realisations (drvPath, outputName, outputPath) \
+                     VALUES ('sha256:a!out', 'out', {a}), ('sha256:b!out', 'out', {b});
+                 INSERT INTO RealisationsRefs (referrer, realisationReference) VALUES (1, 2);"
+            ))
+            .unwrap();
+
+        let dead = [full(&format!("{H1}-a")), full(&format!("{H2}-b"))];
+        t.db.invalidate_paths(dead.iter().map(|s| s.as_str()))
+            .unwrap();
+
+        for table in ["Realisations", "RealisationsRefs", "ValidPaths"] {
+            let n: i64 =
+                t.db.conn
+                    .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+                    .unwrap();
+            assert_eq!(n, 0, "{table} not cleared");
+        }
     }
 
     #[test]

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -62,12 +62,17 @@ impl NixDb {
         // after a grace period, like Nix's busy handler.
         conn.busy_timeout(std::time::Duration::from_secs(60))?;
 
+        // Like Nix's realStoreDir: the physical directory when store_dir
+        // is a symlink (the DB keeps logical paths, disk ops want real
+        // ones). Falls back to the logical dir if it can't be resolved.
+        let real_store_dir =
+            std::fs::canonicalize(store_dir).unwrap_or_else(|_| store_dir.to_path_buf());
         Ok(NixDb {
             conn,
             store_dir: store_dir.to_path_buf(),
             state_dir: state_dir.to_path_buf(),
-            real_store_dir: store_dir.to_path_buf(),
-            links_dir: store_dir.join(".links"),
+            links_dir: real_store_dir.join(".links"),
+            real_store_dir,
             // Read the resolved nix.conf via `nix config show`; defaults
             // match Nix if it's not in PATH.
             keep_derivations: crate::nix_config::bool_setting("keep-derivations", true),

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -138,23 +138,24 @@ impl NixDb {
         let n = paths.len();
         let mut edges: Vec<(u32, u32)> = Vec::new();
 
-        let mut add_edges = |conn: &Connection, sql: &str| -> Result<()> {
-            let mut stmt = conn.prepare(sql)?;
-            let mut rows = stmt.query([])?;
-            while let Some(row) = rows.next()? {
-                let from_id: i64 = row.get(0)?;
-                let to_id: i64 = row.get(1)?;
-                let from = *id_to_idx.get(from_id as usize).unwrap_or(&MISSING);
-                let to = *id_to_idx.get(to_id as usize).unwrap_or(&MISSING);
-                if from != MISSING && to != MISSING {
-                    edges.push((from, to));
+        let mut add_edges =
+            |conn: &Connection, sql: &str, params: &[&dyn rusqlite::ToSql]| -> Result<()> {
+                let mut stmt = conn.prepare(sql)?;
+                let mut rows = stmt.query(params)?;
+                while let Some(row) = rows.next()? {
+                    let from_id: i64 = row.get(0)?;
+                    let to_id: i64 = row.get(1)?;
+                    let from = *id_to_idx.get(from_id as usize).unwrap_or(&MISSING);
+                    let to = *id_to_idx.get(to_id as usize).unwrap_or(&MISSING);
+                    if from != MISSING && to != MISSING {
+                        edges.push((from, to));
+                    }
                 }
-            }
-            Ok(())
-        };
+                Ok(())
+            };
 
         // Refs table: direct references between store paths.
-        add_edges(&self.conn, "SELECT referrer, reference FROM Refs")?;
+        add_edges(&self.conn, "SELECT referrer, reference FROM Refs", &[])?;
 
         // Edge directions mirror Nix's computeFSClosure (misc.cc), which
         // the GC calls with includeOutputs = keep-outputs and
@@ -181,6 +182,7 @@ impl NixDb {
                 "SELECT v.id, d.id FROM ValidPaths v \
                  JOIN ValidPaths d ON d.path = v.deriver \
                  WHERE v.deriver IS NOT NULL",
+                &[],
             )?;
             // output → drv via DerivationOutputs (covers outputs whose
             // deriver column is unset)
@@ -188,16 +190,16 @@ impl NixDb {
                 &self.conn,
                 "SELECT o.id, do2.drv FROM ValidPaths o \
                  JOIN DerivationOutputs do2 ON do2.path = o.path",
+                &[],
             )?;
             if has_build_trace {
                 // output → drv via BuildTraceV3
                 add_edges(
                     &self.conn,
-                    &format!(
-                        "SELECT o.id, d.id FROM BuildTraceV3 bt \
-                         JOIN ValidPaths o ON o.path = bt.outputPath \
-                         JOIN ValidPaths d ON d.path = '{store_prefix}' || bt.drvPath"
-                    ),
+                    "SELECT o.id, d.id FROM BuildTraceV3 bt \
+                     JOIN ValidPaths o ON o.path = bt.outputPath \
+                     JOIN ValidPaths d ON d.path = ? || bt.drvPath",
+                    &[&store_prefix],
                 )?;
             }
         }
@@ -208,6 +210,7 @@ impl NixDb {
                 &self.conn,
                 "SELECT do2.drv, o.id FROM DerivationOutputs do2 \
                  JOIN ValidPaths o ON o.path = do2.path",
+                &[],
             )?;
             // drv → output via ValidPaths.deriver
             add_edges(
@@ -215,16 +218,16 @@ impl NixDb {
                 "SELECT d.id, v.id FROM ValidPaths v \
                  JOIN ValidPaths d ON d.path = v.deriver \
                  WHERE v.deriver IS NOT NULL",
+                &[],
             )?;
             if has_build_trace {
                 // drv → output via BuildTraceV3
                 add_edges(
                     &self.conn,
-                    &format!(
-                        "SELECT d.id, o.id FROM BuildTraceV3 bt \
-                         JOIN ValidPaths d ON d.path = '{store_prefix}' || bt.drvPath \
-                         JOIN ValidPaths o ON o.path = bt.outputPath"
-                    ),
+                    "SELECT d.id, o.id FROM BuildTraceV3 bt \
+                     JOIN ValidPaths d ON d.path = ? || bt.drvPath \
+                     JOIN ValidPaths o ON o.path = bt.outputPath",
+                    &[&store_prefix],
                 )?;
             }
         }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -131,3 +131,4 @@ mod tests {
     }
 }
 pub mod nix_config;
+pub mod temp_roots;

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod db;
+pub mod logging;
 
 use anyhow::{Context, Result};
 use std::path::Path;

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -1,0 +1,46 @@
+//! Minimal stderr logger shared by both binaries: `[LEVEL] message`.
+//! Level controlled by RUST_LOG=error|warn|info|debug|trace (default: info).
+
+use std::io::Write;
+
+struct StderrLogger(log::LevelFilter);
+
+impl log::Log for StderrLogger {
+    fn enabled(&self, m: &log::Metadata) -> bool {
+        m.level() <= self.0
+    }
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            // Ignore write failures: a closed pipe or full disk mid-GC must
+            // not panic the process (eprintln! would).
+            let mut err = std::io::stderr().lock();
+            let _ = writeln!(err, "[{:5}] {}", record.level(), record.args());
+        }
+    }
+    fn flush(&self) {}
+}
+
+/// Install the logger. Panics if a logger is already set.
+pub fn init() {
+    let level = std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(log::LevelFilter::Info);
+    log::set_boxed_logger(Box::new(StderrLogger(level))).unwrap();
+    log::set_max_level(level);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::Log as _;
+
+    #[test]
+    fn respects_level_filter() {
+        let logger = StderrLogger(log::LevelFilter::Info);
+        let info = log::Metadata::builder().level(log::Level::Info).build();
+        let debug = log::Metadata::builder().level(log::Level::Debug).build();
+        assert!(logger.enabled(&info));
+        assert!(!logger.enabled(&debug));
+    }
+}

--- a/crates/common/src/nix_config.rs
+++ b/crates/common/src/nix_config.rs
@@ -19,7 +19,19 @@ pub fn bool_setting(key: &str, default: bool) -> bool {
         .output();
     let out = match out {
         Ok(o) if o.status.success() => o.stdout,
-        _ => return default,
+        // Don't fall back silently: a user who set e.g. keep-outputs=true
+        // in nix.conf should learn why it is being ignored.
+        Ok(o) => {
+            log::warn!(
+                "`nix config show {key}` failed ({}); using default {default}",
+                o.status
+            );
+            return default;
+        }
+        Err(e) => {
+            log::warn!("cannot run `nix config show {key}`: {e}; using default {default}");
+            return default;
+        }
     };
     parse_bool(&out).unwrap_or(default)
 }

--- a/crates/common/src/temp_roots.rs
+++ b/crates/common/src/temp_roots.rs
@@ -1,0 +1,220 @@
+//! Temp-root client, protocol-compatible with Nix's `addTempRoot`
+//! (gc.cc): per-process `temproots/<pid>` file holding NUL-terminated
+//! store paths, registered either under a momentary shared `gc.lock` or
+//! through the running GC's `gc-socket`.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+
+pub struct TempRoots {
+    /// `temproots/<pid>`; we hold the exclusive flock for our lifetime so
+    /// a concurrent GC treats the file as live.
+    file: fs::File,
+    /// `gc.lock` fd; locked shared only for the duration of each `add`.
+    gc_lock: fs::File,
+    socket_path: PathBuf,
+    socket: Option<UnixStream>,
+}
+
+fn flock(f: &fs::File, op: i32) -> std::io::Result<()> {
+    loop {
+        if unsafe { nix::libc::flock(f.as_raw_fd(), op) } == 0 {
+            return Ok(());
+        }
+        let e = std::io::Error::last_os_error();
+        if e.raw_os_error() != Some(nix::libc::EINTR) {
+            return Err(e);
+        }
+    }
+}
+
+impl TempRoots {
+    /// Create (or take over) this process's temp roots file, mirroring
+    /// Nix's `createTempRootsFile`.
+    pub fn create(state_dir: &Path) -> Result<TempRoots> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let dir = state_dir.join("temproots");
+        fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        let path = dir.join(std::process::id().to_string());
+
+        let file = loop {
+            // An existing file with our pid must be stale (no two live
+            // processes share a pid).
+            let _ = fs::remove_file(&path);
+            let f = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(&path)
+                .with_context(|| format!("opening {}", path.display()))?;
+            flock(&f, nix::libc::LOCK_EX).with_context(|| format!("locking {}", path.display()))?;
+            // Non-empty means the GC wrote its "d" marker and unlinked the
+            // file before we got the lock; retry on a fresh inode.
+            if f.metadata()?.len() == 0 {
+                break f;
+            }
+        };
+
+        let gc_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(state_dir.join("gc.lock"))
+            .with_context(|| format!("opening {}", state_dir.join("gc.lock").display()))?;
+
+        Ok(TempRoots {
+            file,
+            gc_lock,
+            socket_path: state_dir.join("gc-socket/socket"),
+            socket: None,
+        })
+    }
+
+    /// Register `store_path` (full path) as a temp root. After this
+    /// returns, no GC will delete the path while this process lives.
+    pub fn add(&mut self, store_path: &str) -> Result<()> {
+        loop {
+            // Shared gc.lock acquirable means no GC is running; holding it
+            // across the file write keeps one from starting mid-register.
+            if flock(&self.gc_lock, nix::libc::LOCK_SH | nix::libc::LOCK_NB).is_ok() {
+                let res = self.write_root(store_path);
+                let _ = flock(&self.gc_lock, nix::libc::LOCK_UN);
+                return res;
+            }
+            // GC running: hand the root to it over the gc-socket. The
+            // socket may vanish at any time (GC finished); restart then.
+            match self.notify_gc(store_path)? {
+                true => return self.write_root(store_path),
+                false => continue,
+            }
+        }
+    }
+
+    fn write_root(&mut self, store_path: &str) -> Result<()> {
+        self.file
+            .write_all(format!("{store_path}\0").as_bytes())
+            .context("writing temp root")
+    }
+
+    /// Send the root to the running GC; Ok(false) means the GC went away
+    /// and the caller should restart with the lock.
+    fn notify_gc(&mut self, store_path: &str) -> Result<bool> {
+        if self.socket.is_none() {
+            match UnixStream::connect(&self.socket_path) {
+                Ok(s) => self.socket = Some(s),
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+                    ) =>
+                {
+                    // GC exited or hasn't created the socket yet.
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    return Ok(false);
+                }
+                Err(e) => {
+                    return Err(e)
+                        .with_context(|| format!("connecting to {}", self.socket_path.display()));
+                }
+            }
+        }
+        let sock = self.socket.as_mut().expect("socket set above");
+        let gone = |e: &std::io::Error| {
+            matches!(
+                e.kind(),
+                std::io::ErrorKind::BrokenPipe
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::UnexpectedEof
+            )
+        };
+        let io = (|| -> std::io::Result<()> {
+            sock.write_all(format!("{store_path}\n").as_bytes())?;
+            let mut ack = [0u8; 1];
+            sock.read_exact(&mut ack)?;
+            if ack != [b'1'] {
+                return Err(std::io::Error::other("unexpected gc-socket ack"));
+            }
+            Ok(())
+        })();
+        match io {
+            Ok(()) => Ok(true),
+            Err(e) if gone(&e) => {
+                self.socket = None;
+                Ok(false)
+            }
+            Err(e) => Err(e).context("talking to gc-socket"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_writes_nul_terminated_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut tr = TempRoots::create(tmp.path()).unwrap();
+        tr.add("/nix/store/aaa-x").unwrap();
+        tr.add("/nix/store/bbb-y").unwrap();
+
+        let path = tmp
+            .path()
+            .join("temproots")
+            .join(std::process::id().to_string());
+        let data = fs::read(&path).unwrap();
+        assert_eq!(data, b"/nix/store/aaa-x\0/nix/store/bbb-y\0");
+        // We hold the write lock, so the file reads as live to a GC.
+        let f = fs::File::open(&path).unwrap();
+        assert!(flock(&f, nix::libc::LOCK_EX | nix::libc::LOCK_NB).is_err());
+    }
+
+    #[test]
+    fn add_uses_gc_socket_when_gc_holds_the_lock() {
+        use std::io::BufRead;
+        use std::os::unix::net::UnixListener;
+
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Simulate a running GC: exclusive gc.lock + listening socket.
+        let gc_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(tmp.path().join("gc.lock"))
+            .unwrap();
+        flock(&gc_lock, nix::libc::LOCK_EX).unwrap();
+        fs::create_dir_all(tmp.path().join("gc-socket")).unwrap();
+        let listener = UnixListener::bind(tmp.path().join("gc-socket/socket")).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut writer = stream.try_clone().unwrap();
+            let mut line = String::new();
+            std::io::BufReader::new(stream)
+                .read_line(&mut line)
+                .unwrap();
+            writer.write_all(b"1").unwrap();
+            line
+        });
+
+        let mut tr = TempRoots::create(tmp.path()).unwrap();
+        tr.add("/nix/store/ccc-z").unwrap();
+
+        assert_eq!(server.join().unwrap(), "/nix/store/ccc-z\n");
+        let path = tmp
+            .path()
+            .join("temproots")
+            .join(std::process::id().to_string());
+        assert_eq!(fs::read(&path).unwrap(), b"/nix/store/ccc-z\0");
+    }
+}

--- a/crates/gc/Cargo.toml
+++ b/crates/gc/Cargo.toml
@@ -12,8 +12,6 @@ walkdir.workspace = true
 anyhow.workspace = true
 nix.workspace = true
 log.workspace = true
-rusqlite.workspace = true
-foldhash.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -5,6 +5,7 @@ use crate::gc_socket::{GcSocketServer, LiveSet};
 use crate::roots::{find_roots, find_temp_roots};
 use crate::{format_size, make_store_writable};
 use anyhow::{Context, Result};
+use nix::fcntl::{Flock, FlockArg};
 use rayon::prelude::*;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
@@ -66,8 +67,6 @@ fn delete_store_path(real_path: &Path) -> Result<u64> {
 
     Ok(bytes_freed)
 }
-
-use nix::fcntl::{Flock, FlockArg};
 
 /// Lock a `tmp-*` build dir before deleting. None means a builder still
 /// holds it. Caller keeps the fd through deletion to avoid a TOCTOU race.

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -326,42 +326,41 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
                 i += 1;
             }
         }
-        // Snapshot-filter, don't pre-claim: protect() should wait for the
-        // rayon-bounded in-flight set, not the whole chunk.
-        let (mut claimed, skipped): (Vec<u32>, Vec<u32>) =
-            chunk.iter().copied().partition(|&n| !live.is_protected(n));
-        // protect() marks closures atomically, but this filter reads one
-        // node at a time: it may have kept a reference whose referrer got
-        // protected a moment later. Drop the closures of skipped paths.
+        // Claim (mark pending) atomically with the protection check,
+        // *before* invalidating DB rows. A protect() arriving later for a
+        // claimed node blocks until the unlink finished, so a builder is
+        // never acked while the row deletion is still in flight — it sees
+        // a consistent "gone" state and re-registers.
+        let (mut claimed, skipped) = live.claim_nodes(&chunk);
+        // protect() marks closures atomically, but the claim is per node:
+        // it may have kept a reference whose referrer got protected a
+        // moment earlier. Drop the closures of skipped paths.
         if !skipped.is_empty() {
             let keep_out = graph.compute_closure(&skipped);
-            claimed.retain(|&n| !keep_out[n as usize]);
+            claimed.retain(|&n| {
+                if keep_out[n as usize] {
+                    live.end_delete_node(n);
+                    false
+                } else {
+                    true
+                }
+            });
         }
         // Invalidate rows before unlinking: builders trust isValidPath(),
         // so a path must never look valid after its disk entry is gone.
-        // Paths protected after this point stay on disk; their builder
-        // re-registers them or the next run collects them as
-        // unknown-on-disk. See alloy/gc_db_consistency.als.
+        // See alloy/gc_db_consistency.als.
         db.invalidate_paths(claimed.iter().map(|&n| graph.paths[n as usize].as_str()))?;
-        let n_deleted = claimed
-            .par_iter()
-            .copied()
-            .filter(|&node| {
-                if !live.try_begin_delete_node(node) {
-                    return false;
-                }
-                let path = &graph.paths[node as usize];
-                let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
-                let real_path = real_store_dir.join(basename);
-                log::debug!("deleting '{path}'");
-                if let Ok(freed) = delete_store_path(&real_path) {
-                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
-                }
-                live.end_delete_node(node);
-                true
-            })
-            .count();
-        paths_deleted.fetch_add(n_deleted as u64, Ordering::Relaxed);
+        claimed.par_iter().for_each(|&node| {
+            let path = &graph.paths[node as usize];
+            let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
+            let real_path = real_store_dir.join(basename);
+            log::debug!("deleting '{path}'");
+            if let Ok(freed) = delete_store_path(&real_path) {
+                bytes_freed.fetch_add(freed, Ordering::Relaxed);
+            }
+            live.end_delete_node(node);
+        });
+        paths_deleted.fetch_add(claimed.len() as u64, Ordering::Relaxed);
     }
 
     // Unknown-on-disk paths: also parallel. tmp-* dirs hold flock through

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -448,53 +448,56 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     let paths_deleted = paths_deleted.into_inner() as usize;
 
     // Clean up unused hard links in .links
-    if !dry_run {
-        clean_links(&db.links_dir)?;
-    }
+    let bytes_freed = bytes_freed + clean_links(&db.links_dir)?;
 
     Ok((bytes_freed, paths_deleted))
 }
 
-/// Remove hard links with link count 1 from .links directory.
-/// The .links dir can contain millions of entries; stat + unlink per entry
-/// is disk-bound, so process in parallel.
-fn clean_links(links_dir: &Path) -> Result<()> {
-    use std::sync::atomic::AtomicI64;
-
+/// Remove hard links with link count 1 from .links directory, returning
+/// bytes freed. The .links dir can contain millions of entries; stat +
+/// unlink per entry is disk-bound, so process in parallel. Stream the
+/// entries instead of collecting them: a Vec of millions of DirEntries
+/// costs gigabytes of RSS.
+fn clean_links(links_dir: &Path) -> Result<u64> {
     log::info!("deleting unused links...");
-    let entries: Vec<_> = match fs::read_dir(links_dir) {
-        Ok(e) => e.flatten().collect(),
-        Err(_) => return Ok(()),
+    let entries = match fs::read_dir(links_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            log::warn!("cannot read {}: {e}", links_dir.display());
+            return Ok(0);
+        }
     };
 
-    // For each surviving link with N references, hard linking saves
-    // (N-1)*size bytes compared to N independent copies.
-    let saved_bytes = AtomicI64::new(0);
+    // A link entry has one reference from .links plus one per store file.
+    // N references total mean hard linking saves (N-2)*size compared to
+    // independent copies.
+    let saved_bytes = AtomicU64::new(0);
+    let freed_bytes = AtomicU64::new(0);
 
-    entries.par_iter().for_each(|entry| {
+    entries.flatten().par_bridge().for_each(|entry| {
         let path = entry.path();
         let Ok(meta) = fs::symlink_metadata(&path) else {
             return;
         };
         if meta.nlink() != 1 {
             saved_bytes.fetch_add(
-                (meta.nlink() as i64 - 1) * meta.size() as i64,
+                meta.nlink().saturating_sub(2) * meta.size(),
                 Ordering::Relaxed,
             );
             return;
         }
-        fs::remove_file(&path).ok();
+        if fs::remove_file(&path).is_ok() {
+            freed_bytes.fetch_add(meta.blocks() * 512, Ordering::Relaxed);
+        }
     });
 
     let saving = saved_bytes.into_inner();
     if saving > 0 {
-        log::info!(
-            "hard linking is currently saving {}",
-            format_size(saving as u64)
-        );
+        log::info!("hard linking is currently saving {}", format_size(saving));
     }
 
-    Ok(())
+    Ok(freed_bytes.into_inner())
 }
 
 #[cfg(test)]
@@ -566,11 +569,13 @@ mod tests {
         fs::write(&shared, b"referenced").unwrap();
         fs::hard_link(&shared, tmp.path().join("user")).unwrap();
 
-        clean_links(&links).unwrap();
+        let dead_blocks = fs::symlink_metadata(&dead).unwrap().blocks() * 512;
+        let freed = clean_links(&links).unwrap();
 
         assert!(!dead.exists());
         assert!(shared.exists());
+        assert_eq!(freed, dead_blocks, "freed bytes of removed links");
         // Missing .links dir is not an error.
-        clean_links(&tmp.path().join("nope")).unwrap();
+        assert_eq!(clean_links(&tmp.path().join("nope")).unwrap(), 0);
     }
 }

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -150,24 +150,61 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         make_store_writable(&db.real_store_dir)?;
     }
 
+    // Serve the gc-socket immediately after taking the lock, like Nix:
+    // builders that lost the shared-lock race retry connecting every
+    // 100ms, so the socket must exist before the (potentially long)
+    // graph load — and during dry runs, which hold the lock too.
+    //
+    // Phase 1: no graph yet, so every received root is acked instantly
+    // and recorded by basename. That is sound because nothing can be
+    // deleted before the graph exists; the roots are replayed below.
+    let store_prefix = format!("{}/", db.store_dir.display());
+    let early_live = Arc::new(LiveSet::new(0));
+    // A dry run on a read-only state dir can still report; without the
+    // socket no builder can run anyway (they need temproots).
+    let start_socket = |live: Arc<LiveSet>, graph: Arc<crate::db::StoreGraph>| -> Result<_> {
+        match GcSocketServer::start(&db.state_dir, live, graph) {
+            Ok(s) => Ok(Some(s)),
+            Err(e) if dry_run => {
+                log::warn!("cannot serve gc-socket: {e:#}");
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    };
+    let early_socket = start_socket(
+        Arc::clone(&early_live),
+        Arc::new(crate::db::StoreGraph::empty(store_prefix.clone())),
+    )?;
+
+    // Test sync point: block until the named fifo is readable, so tests
+    // can deterministically exercise the early-socket window.
+    if let Ok(p) = std::env::var("_FAST_NIX_GC_TEST_SYNC_EARLY") {
+        let _ = fs::read(&p);
+    }
+
     log::info!("loading store graph...");
     let graph = Arc::new(db.load_graph()?);
     log::info!("{} total valid paths", graph.len());
 
-    // Start the gc-socket as soon as the graph is loaded so builders stop
-    // busy-polling gc.lock. Roots received only shrink the dead set.
+    // Phase 2: swap to the real server. Builders whose connection drops
+    // during the swap reconnect (Nix's addTempRoot restart loop).
+    drop(early_socket);
+    let early_roots = early_live.protected_unknown_snapshot();
     let live = Arc::new(LiveSet::new(graph.len()));
-    let _gc_socket = if dry_run {
-        None
-    } else {
-        Some(GcSocketServer::start(
-            &db.state_dir,
-            Arc::clone(&live),
-            Arc::clone(&graph),
-        )?)
-    };
+    let _gc_socket = start_socket(Arc::clone(&live), Arc::clone(&graph))?;
 
     let bidx = BasenameIndex::new(&graph);
+
+    // Replay phase-1 roots: known paths become ordinary GC roots (their
+    // closure stays alive), unknown basenames stay protected.
+    let mut early_root_idxs: Vec<u32> = Vec::new();
+    for b in &early_roots {
+        match bidx.idx_of_basename(b) {
+            Some(i) => early_root_idxs.push(i),
+            None => live.protect_unknown_basename(b),
+        }
+    }
 
     // A --store-dir that doesn't match the DB contents (wrong directory)
     // would make every root lookup miss and every DB path look dead,
@@ -183,6 +220,7 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
 
     log::info!("finding garbage collector roots...");
     let mut roots = find_roots(&db.state_dir, &db.store_dir, &bidx)?;
+    roots.extend(early_root_idxs);
 
     // Add temp roots. Some may reference paths registered after our
     // graph snapshot (a builder can register paths while we hold
@@ -275,15 +313,25 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         let mut stdout = std::io::BufWriter::new(std::io::stdout().lock());
         let mut estimated = 0u64;
         let mut count = 0usize;
+        // Roots can arrive over the gc-socket while we run; a real GC
+        // would honor them, so the report must too.
+        let protected = live.protected_snapshot();
+        let protected_unknown = live.protected_unknown_snapshot();
         for &node in &dead_indices {
             if estimated >= max {
                 break;
+            }
+            if protected[node as usize] {
+                continue;
             }
             writeln!(stdout, "{}", graph.paths[node as usize])?;
             estimated += graph.nar_sizes[node as usize];
             count += 1;
         }
         for name in &unknown_on_disk {
+            if name.to_str().is_some_and(|n| protected_unknown.contains(n)) {
+                continue;
+            }
             writeln!(stdout, "{store_prefix}{}", name.display())?;
             count += 1;
         }

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -152,7 +152,7 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     }
 
     log::info!("finding garbage collector roots...");
-    let mut roots = find_roots(&db.state_dir, &db.store_dir, &bidx);
+    let mut roots = find_roots(&db.state_dir, &db.store_dir, &bidx)?;
 
     // Add temp roots. Some may reference paths registered after our
     // graph snapshot (a builder can register paths while we hold

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -139,6 +139,18 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
 
     let bidx = BasenameIndex::new(&graph);
 
+    // A --store-dir that doesn't match the DB contents (wrong directory)
+    // would make every root lookup miss and every DB path look dead,
+    // wiping the store. Refuse to proceed.
+    if !graph.is_empty() && bidx.map.is_empty() {
+        anyhow::bail!(
+            "store dir {} does not match any path in the Nix database \
+             (e.g. {}); refusing to collect garbage",
+            db.store_dir.display(),
+            graph.paths[0],
+        );
+    }
+
     log::info!("finding garbage collector roots...");
     let mut roots = find_roots(&db.state_dir, &db.store_dir, &bidx);
 

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -157,7 +157,7 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
 
     // Start the gc-socket as soon as the graph is loaded so builders stop
     // busy-polling gc.lock. Roots received only shrink the dead set.
-    let live = Arc::new(LiveSet::new(graph.len(), crate::HashSet::default()));
+    let live = Arc::new(LiveSet::new(graph.len()));
     let _gc_socket = if dry_run {
         None
     } else {

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -94,12 +94,16 @@ fn try_lock_dir(path: &Path) -> Option<Flock<fs::File>> {
 /// Same lock Nix takes. Builders hold it shared while registering temp
 /// roots; we take it exclusive so the root set can't change under us.
 fn acquire_gc_lock(state_dir: &Path) -> Result<Flock<fs::File>> {
+    use std::os::unix::fs::OpenOptionsExt;
     let lock_path = state_dir.join("gc.lock");
+    // 0600 like Nix's openLockFile: a world-readable lock would let any
+    // local user flock it and block GC and builders indefinitely.
     let f = fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(false)
+        .mode(0o600)
         .open(&lock_path)
         .with_context(|| format!("opening GC lock {}", lock_path.display()))?;
 
@@ -129,6 +133,18 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     // Acquire the global GC lock before anything else. Builders take a
     // shared lock when adding temp roots; holding the exclusive lock
     // ensures no new roots appear after we scan them.
+    // Free the reserved space file first (Nix: deletePath(reservedPath)).
+    // On a 100% full disk the SQLite invalidation below needs room to
+    // write before any store path has been unlinked.
+    if !dry_run {
+        let reserved = db.state_dir.join("db/reserved");
+        match fs::remove_file(&reserved) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => log::warn!("cannot remove {}: {e}", reserved.display()),
+        }
+    }
+
     let _gc_lock = acquire_gc_lock(&db.state_dir)?;
 
     if !dry_run {

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -160,11 +160,22 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     // Track those by basename so the unknown-on-disk scan won't
     // delete them.
     let mut temp_root_basenames: crate::HashSet<String> = crate::HashSet::default();
+    // Hash parts of all temp roots. Nix matches temp roots by hash part so
+    // that sibling files of an active build (`<path>.lock`, `<path>.chroot`,
+    // `<path>.check`) are protected too; the unknown-on-disk scan must not
+    // delete a lock file another builder currently holds.
+    let mut temp_root_hashes: crate::HashSet<String> = crate::HashSet::default();
     for tr in find_temp_roots(&db.state_dir)? {
+        if let Some(b) = tr.strip_prefix(graph.store_prefix.as_str()) {
+            if b.len() > 32 && b.as_bytes()[32] == b'-' {
+                temp_root_hashes.insert(b[..32].to_owned());
+            }
+            if bidx.idx_of_basename(b).is_none() {
+                temp_root_basenames.insert(b.to_owned());
+            }
+        }
         if let Some(i) = bidx.idx_of(&tr) {
             roots.push(i);
-        } else if let Some(b) = tr.strip_prefix(graph.store_prefix.as_str()) {
-            temp_root_basenames.insert(b.to_owned());
         }
     }
     // --keep-recent: treat recently registered paths as roots.
@@ -201,8 +212,14 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
             if name == ".links" {
                 continue;
             }
+            // An entry shares an active build's hash part if its first 32
+            // chars match (covers `<path>.lock` and friends).
+            let hash_part_active = name.len() >= 32
+                && name.is_char_boundary(32)
+                && temp_root_hashes.contains(&name[..32]);
             if bidx.idx_of_basename(name.as_ref()).is_none()
                 && !temp_root_basenames.contains(name.as_ref())
+                && !hash_part_active
             {
                 unknown_on_disk.push(name.into_owned());
             }

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -72,7 +72,22 @@ use nix::fcntl::{Flock, FlockArg};
 /// Lock a `tmp-*` build dir before deleting. None means a builder still
 /// holds it. Caller keeps the fd through deletion to avoid a TOCTOU race.
 fn try_lock_dir(path: &Path) -> Option<Flock<fs::File>> {
-    let f = fs::File::open(path).ok()?;
+    use std::os::unix::fs::OpenOptionsExt;
+    // O_NONBLOCK: a stray FIFO named tmp-* must not block open() forever
+    // while we hold the exclusive gc.lock.
+    let f = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                log::warn!("cannot open {} for locking: {e}", path.display());
+            }
+            return None;
+        }
+    };
     Flock::lock(f, FlockArg::LockExclusiveNonblock).ok()
 }
 
@@ -203,26 +218,31 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     // Also find entries on disk that aren't in the DB at all.
     // Compare by basename to avoid allocating a full-path string per entry.
     let store_prefix = graph.store_prefix.clone();
-    let mut unknown_on_disk: Vec<String> = Vec::new();
+    // Raw OsString names: a non-UTF-8 entry can't be in the DB (it stores
+    // text), but it is still garbage that must be unlinked by its real
+    // bytes — a lossy name would aim remove_file at a nonexistent path.
+    let mut unknown_on_disk: Vec<std::ffi::OsString> = Vec::new();
     if let Ok(entries) = fs::read_dir(&db.real_store_dir) {
         for entry in entries.flatten() {
             let raw = entry.file_name();
-            let name = raw.to_string_lossy();
             // read_dir never yields "." or "..".
-            if name == ".links" {
-                continue;
+            if let Some(name) = raw.to_str() {
+                if name == ".links" {
+                    continue;
+                }
+                // An entry shares an active build's hash part if its first
+                // 32 chars match (covers `<path>.lock` and friends).
+                let hash_part_active = name.len() >= 32
+                    && name.is_char_boundary(32)
+                    && temp_root_hashes.contains(&name[..32]);
+                if bidx.idx_of_basename(name).is_some()
+                    || temp_root_basenames.contains(name)
+                    || hash_part_active
+                {
+                    continue;
+                }
             }
-            // An entry shares an active build's hash part if its first 32
-            // chars match (covers `<path>.lock` and friends).
-            let hash_part_active = name.len() >= 32
-                && name.is_char_boundary(32)
-                && temp_root_hashes.contains(&name[..32]);
-            if bidx.idx_of_basename(name.as_ref()).is_none()
-                && !temp_root_basenames.contains(name.as_ref())
-                && !hash_part_active
-            {
-                unknown_on_disk.push(name.into_owned());
-            }
+            unknown_on_disk.push(raw);
         }
     }
     if !unknown_on_disk.is_empty() {
@@ -249,7 +269,7 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
             count += 1;
         }
         for name in &unknown_on_disk {
-            writeln!(stdout, "{store_prefix}{name}")?;
+            writeln!(stdout, "{store_prefix}{}", name.display())?;
             count += 1;
         }
         return Ok((estimated, count));
@@ -355,8 +375,13 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
             let basename = path.strip_prefix(&store_prefix).unwrap_or(path);
             let real_path = real_store_dir.join(basename);
             log::debug!("deleting '{path}'");
-            if let Ok(freed) = delete_store_path(&real_path) {
-                bytes_freed.fetch_add(freed, Ordering::Relaxed);
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                }
+                // Row already invalidated; the leftover is picked up as
+                // unknown-on-disk by the next run.
+                Err(e) => log::warn!("failed to delete {}: {e:#}", real_path.display()),
             }
             live.end_delete_node(node);
         });
@@ -374,26 +399,33 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         // shielded by protected_unknown. See tempRootStale in
         // alloy/gc_db_consistency.als.
         let mut unknown_on_disk = unknown_on_disk;
-        unknown_on_disk.retain(
-            |name| match db.is_valid_path(&format!("{store_prefix}{name}")) {
+        unknown_on_disk.retain(|name| {
+            // A non-UTF-8 name can't be a DB path (the DB stores text).
+            let Some(name) = name.to_str() else {
+                return true;
+            };
+            match db.is_valid_path(&format!("{store_prefix}{name}")) {
                 Ok(valid) => !valid,
                 Err(e) => {
                     log::warn!("skipping {store_prefix}{name}: validity check failed: {e}");
                     false
                 }
-            },
-        );
-        unknown_on_disk.par_iter().for_each(|name| {
-            if !live.try_begin_delete_unknown(name) {
+            }
+        });
+        unknown_on_disk.par_iter().for_each(|raw| {
+            // The liveset/protocol key is textual; non-UTF-8 names can't
+            // collide with anything a builder protects.
+            let name = raw.to_string_lossy();
+            if !live.try_begin_delete_unknown(&name) {
                 return;
             }
-            let real_path = real_store_dir.join(name);
+            let real_path = real_store_dir.join(raw);
             let _tmp_lock = if name.starts_with("tmp-") {
                 match try_lock_dir(&real_path) {
                     Some(f) => Some(f),
                     None => {
                         log::debug!("skipping locked tempdir {}", real_path.display());
-                        live.end_delete_unknown(name);
+                        live.end_delete_unknown(&name);
                         return;
                     }
                 }
@@ -401,11 +433,14 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
                 None
             };
             log::debug!("deleting '{store_prefix}{name}'");
-            if let Ok(freed) = delete_store_path(&real_path) {
-                bytes_freed.fetch_add(freed, Ordering::Relaxed);
+            match delete_store_path(&real_path) {
+                Ok(freed) => {
+                    bytes_freed.fetch_add(freed, Ordering::Relaxed);
+                    paths_deleted.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(e) => log::warn!("failed to delete {}: {e:#}", real_path.display()),
             }
-            live.end_delete_unknown(name);
-            paths_deleted.fetch_add(1, Ordering::Relaxed);
+            live.end_delete_unknown(&name);
         });
     }
 

--- a/crates/gc/src/gc_socket.rs
+++ b/crates/gc/src/gc_socket.rs
@@ -10,7 +10,7 @@ use crate::{HashMap, HashSet};
 use anyhow::{Context, Result};
 use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use std::fs;
-use std::io::{BufRead, BufReader, ErrorKind, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::AsFd;
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -217,7 +217,13 @@ fn accept_loop(
     while !shutdown.load(Ordering::Acquire) {
         let pfd = PollFd::new(listener.as_fd(), PollFlags::POLLIN);
         match poll(&mut [pfd], PollTimeout::from(10_u8)) {
-            Ok(0) | Err(_) => continue,
+            Ok(0) => continue,
+            Err(e) => {
+                // Don't hot-spin if poll fails persistently.
+                log::debug!("gc-socket poll: {e}");
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                continue;
+            }
             _ => {}
         }
         match listener.accept() {
@@ -238,8 +244,11 @@ fn accept_loop(
             }
             Err(e) if e.kind() == ErrorKind::Interrupted => {}
             Err(e) => {
-                log::debug!("gc-socket accept: {e}");
-                break;
+                // Transient failures (EMFILE/ENFILE/ECONNABORTED) must not
+                // kill the server: builders would stall for the rest of the
+                // GC. Back off briefly and keep accepting.
+                log::warn!("gc-socket accept: {e}");
+                std::thread::sleep(std::time::Duration::from_millis(100));
             }
         }
     }
@@ -252,13 +261,20 @@ fn handle_client(
     graph: &StoreGraph,
     idx: &HashMap<String, u32>,
 ) -> Result<()> {
+    // Paths are bounded; a peer that streams gigabytes without a newline
+    // must not OOM the GC (the socket is world-writable, like Nix's).
+    const MAX_LINE: u64 = 64 * 1024;
     let mut writer = stream.try_clone()?;
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
     loop {
         line.clear();
-        if reader.read_line(&mut line)? == 0 {
+        let n = reader.by_ref().take(MAX_LINE).read_line(&mut line)?;
+        if n == 0 {
             return Ok(());
+        }
+        if n as u64 == MAX_LINE && !line.ends_with('\n') {
+            anyhow::bail!("gc-socket: line too long");
         }
         let path = line.trim_end_matches('\n');
         if let Some(basename) = path.strip_prefix(store_prefix).filter(|b| !b.is_empty()) {

--- a/crates/gc/src/gc_socket.rs
+++ b/crates/gc/src/gc_socket.rs
@@ -30,6 +30,9 @@ pub struct LiveSet {
 }
 
 struct LiveInner {
+    /// Set when the GC is tearing down (possibly on an error path with
+    /// unlinks still marked pending); protect() must stop waiting.
+    cancelled: bool,
     /// Per-node "do not delete" flag, indexed by graph node id.
     protected: Vec<bool>,
     /// Basenames protected that are not (yet) in the graph. Covers paths a
@@ -45,6 +48,7 @@ impl LiveSet {
     pub fn new(n_nodes: usize) -> Self {
         LiveSet {
             inner: Mutex::new(LiveInner {
+                cancelled: false,
                 protected: vec![false; n_nodes],
                 protected_unknown: HashSet::default(),
                 pending_nodes: HashSet::default(),
@@ -70,6 +74,26 @@ impl LiveSet {
         g.pending_nodes.remove(&node);
         drop(g);
         self.cond.notify_all();
+    }
+
+    /// Snapshot of per-node protection flags (dry-run reporting).
+    pub fn protected_snapshot(&self) -> Vec<bool> {
+        self.inner.lock().unwrap().protected.clone()
+    }
+
+    /// Snapshot of protected basenames that are not in the graph.
+    pub fn protected_unknown_snapshot(&self) -> HashSet<String> {
+        self.inner.lock().unwrap().protected_unknown.clone()
+    }
+
+    /// Mark a basename outside the graph as protected (used to carry
+    /// over roots received before the graph was loaded).
+    pub fn protect_unknown_basename(&self, basename: &str) {
+        self.inner
+            .lock()
+            .unwrap()
+            .protected_unknown
+            .insert(basename.to_owned());
     }
 
     /// Atomically partition `nodes` into (claimed, skipped): skipped nodes
@@ -141,12 +165,22 @@ impl LiveSet {
             wait_for.iter().any(|n| g.pending_nodes.contains(n))
                 || g.pending_unknown.contains(basename)
         };
-        while conflict(&g) {
+        while conflict(&g) && !g.cancelled {
             log::debug!("synchronising with deletion of {basename}");
             g = self.cond.wait(g).unwrap();
         }
     }
+
+    /// Unblock every waiting protect(): used on GC teardown, where an
+    /// error path may leave pending nodes that will never finish.
+    fn cancel(&self) {
+        self.inner.lock().unwrap().cancelled = true;
+        self.cond.notify_all();
+    }
 }
+
+/// Client connections and their handler threads, owned by the server.
+type Conns = Arc<Mutex<Vec<(UnixStream, JoinHandle<()>)>>>;
 
 /// Running GC roots socket server. Dropping it tears down the listener,
 /// removes the socket file, and joins the accept thread.
@@ -154,6 +188,11 @@ pub struct GcSocketServer {
     socket_path: PathBuf,
     shutdown: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
+    live: Arc<LiveSet>,
+    /// Live client connections; Drop shuts them down and joins their
+    /// handler threads so no `protect()` is still running afterwards —
+    /// callers snapshot the LiveSet right after dropping the server.
+    conns: Conns,
 }
 
 impl GcSocketServer {
@@ -180,18 +219,33 @@ impl GcSocketServer {
         }
         let idx = Arc::new(idx);
         let store_prefix = graph.store_prefix.clone();
+        let live_for_drop = Arc::clone(&live);
         let shutdown = Arc::new(AtomicBool::new(false));
         let accept_shutdown = Arc::clone(&shutdown);
+        let conns: Conns = Arc::new(Mutex::new(Vec::new()));
+        let accept_conns = Arc::clone(&conns);
 
         let handle = std::thread::Builder::new()
             .name("gc-socket".into())
-            .spawn(move || accept_loop(listener, store_prefix, live, graph, idx, accept_shutdown))
+            .spawn(move || {
+                accept_loop(
+                    listener,
+                    store_prefix,
+                    live,
+                    graph,
+                    idx,
+                    accept_shutdown,
+                    accept_conns,
+                )
+            })
             .context("spawning gc-socket thread")?;
 
         Ok(GcSocketServer {
             socket_path,
             shutdown,
             handle: Some(handle),
+            live: live_for_drop,
+            conns,
         })
     }
 }
@@ -203,6 +257,18 @@ impl Drop for GcSocketServer {
         if let Some(h) = self.handle.take() {
             let _ = h.join();
         }
+        // Force-close every client connection and join its handler. A
+        // mid-flight protect() finishes (its root is recorded) before the
+        // handler observes EOF/EPIPE and exits; unacked clients reconnect
+        // via Nix's addTempRoot restart loop. Cancel first so a protect()
+        // stuck on nodes an aborted deletion loop left pending cannot
+        // deadlock the join.
+        self.live.cancel();
+        let conns = std::mem::take(&mut *self.conns.lock().unwrap());
+        for (stream, handle) in conns {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+            let _ = handle.join();
+        }
     }
 }
 
@@ -213,6 +279,7 @@ fn accept_loop(
     graph: Arc<StoreGraph>,
     idx: Arc<HashMap<String, u32>>,
     shutdown: Arc<AtomicBool>,
+    conns: Conns,
 ) {
     while !shutdown.load(Ordering::Acquire) {
         let pfd = PollFd::new(listener.as_fd(), PollFlags::POLLIN);
@@ -232,15 +299,25 @@ fn accept_loop(
                 let live = Arc::clone(&live);
                 let graph = Arc::clone(&graph);
                 let idx = Arc::clone(&idx);
+                let Ok(stream2) = stream.try_clone() else {
+                    continue;
+                };
                 // Each builder keeps its connection open for the duration of
                 // its build; handle them concurrently.
-                let _ = std::thread::Builder::new()
+                let spawned = std::thread::Builder::new()
                     .name("gc-socket-conn".into())
                     .spawn(move || {
                         if let Err(e) = handle_client(stream, &store_prefix, &live, &graph, &idx) {
                             log::debug!("gc-socket client: {e}");
                         }
                     });
+                if let Ok(handle) = spawned {
+                    let mut g = conns.lock().unwrap();
+                    // Drop entries whose handler already exited so the list
+                    // doesn't grow with every short-lived connection.
+                    g.retain(|(_, h)| !h.is_finished());
+                    g.push((stream2, handle));
+                }
             }
             Err(e) if e.kind() == ErrorKind::Interrupted => {}
             Err(e) => {
@@ -458,6 +535,41 @@ mod tests {
         conn.set_read_timeout(None).unwrap();
         conn.read_exact(&mut ack).unwrap();
         assert_eq!(ack, [b'1']);
+    }
+
+    #[test]
+    fn drop_joins_handlers_and_snapshot_sees_acked_roots() {
+        // Phase-1/phase-2 swap in the GC: every root acked before the
+        // server is dropped must be visible in the snapshot taken right
+        // after, even though the client connection is still open (its
+        // handler thread must be terminated and joined, not detached).
+        let g = Arc::new(graph("/nix/store/", &[]));
+        let live = Arc::new(LiveSet::new(0));
+        let dir = tempfile::tempdir().unwrap();
+        let server = GcSocketServer::start(dir.path(), Arc::clone(&live), g).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/early-root\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
+
+        // Handler is now blocked in read_line on the open connection;
+        // drop must not hang and must complete the handler first.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let joiner = std::thread::spawn(move || {
+            drop(server);
+            let _ = tx.send(());
+        });
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("GcSocketServer::drop hung joining a live connection");
+        joiner.join().unwrap();
+
+        assert!(
+            live.protected_unknown_snapshot().contains("early-root"),
+            "acked root missing from post-drop snapshot"
+        );
     }
 
     #[test]

--- a/crates/gc/src/gc_socket.rs
+++ b/crates/gc/src/gc_socket.rs
@@ -54,11 +54,6 @@ impl LiveSet {
         }
     }
 
-    /// Snapshot read; not a delete claim, does not block `protect()`.
-    pub fn is_protected(&self, node: u32) -> bool {
-        self.inner.lock().unwrap().protected[node as usize]
-    }
-
     /// Atomically check that `node` is unprotected and mark it pending.
     /// Returns `false` (skip deletion) if the node was protected meanwhile.
     pub fn try_begin_delete_node(&self, node: u32) -> bool {
@@ -75,6 +70,27 @@ impl LiveSet {
         g.pending_nodes.remove(&node);
         drop(g);
         self.cond.notify_all();
+    }
+
+    /// Atomically partition `nodes` into (claimed, skipped): skipped nodes
+    /// are protected; claimed ones are marked pending in the same critical
+    /// section. Claiming before the DB invalidation closes the race where
+    /// `protect()` acks a path whose ValidPaths row is about to be deleted:
+    /// any later `protect()` of a claimed node blocks until its unlink
+    /// finished, so the builder re-checks validity and re-registers.
+    pub fn claim_nodes(&self, nodes: &[u32]) -> (Vec<u32>, Vec<u32>) {
+        let mut g = self.inner.lock().unwrap();
+        let mut claimed = Vec::with_capacity(nodes.len());
+        let mut skipped = Vec::new();
+        for &n in nodes {
+            if g.protected[n as usize] {
+                skipped.push(n);
+            } else {
+                g.pending_nodes.insert(n);
+                claimed.push(n);
+            }
+        }
+        (claimed, skipped)
     }
 
     /// Same as `try_begin_delete_node` for paths not in the graph.
@@ -394,6 +410,38 @@ mod tests {
             conn.read_exact(&mut ack).unwrap();
             assert_eq!(ack, [b'1']);
         }
+    }
+
+    #[test]
+    fn claim_nodes_partitions_and_blocks_protect() {
+        let g = Arc::new(graph("/nix/store/", &[("a", &[]), ("b", &[])]));
+        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let dir = tempfile::tempdir().unwrap();
+        let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
+        let sock = dir.path().join("gc-socket/socket");
+
+        // Protect b up front; claim must skip it and claim a.
+        let mut conn = UnixStream::connect(&sock).unwrap();
+        conn.write_all(b"/nix/store/b\n").unwrap();
+        let mut ack = [0u8; 1];
+        conn.read_exact(&mut ack).unwrap();
+
+        let (claimed, skipped) = live.claim_nodes(&[0, 1]);
+        assert_eq!(claimed, vec![0]);
+        assert_eq!(skipped, vec![1]);
+
+        // A protect for the claimed node must block until its unlink is
+        // done (the DB row is already gone; acking earlier would tell the
+        // builder a deleted row is protected).
+        conn.write_all(b"/nix/store/a\n").unwrap();
+        conn.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        assert!(conn.read_exact(&mut ack).is_err(), "acked mid-deletion");
+
+        live.end_delete_node(0);
+        conn.set_read_timeout(None).unwrap();
+        conn.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, [b'1']);
     }
 
     #[test]

--- a/crates/gc/src/gc_socket.rs
+++ b/crates/gc/src/gc_socket.rs
@@ -42,11 +42,11 @@ struct LiveInner {
 }
 
 impl LiveSet {
-    pub fn new(n_nodes: usize, protected_unknown: HashSet<String>) -> Self {
+    pub fn new(n_nodes: usize) -> Self {
         LiveSet {
             inner: Mutex::new(LiveInner {
                 protected: vec![false; n_nodes],
-                protected_unknown,
+                protected_unknown: HashSet::default(),
                 pending_nodes: HashSet::default(),
                 pending_unknown: HashSet::default(),
             }),
@@ -313,7 +313,7 @@ mod tests {
     #[test]
     fn drop_returns_when_idle_accept_loop_is_waiting() {
         let g = Arc::new(graph("/nix/store/", &[]));
-        let live = Arc::new(LiveSet::new(0, HashSet::default()));
+        let live = Arc::new(LiveSet::new(0));
         let dir = tempfile::tempdir().unwrap();
         let server = GcSocketServer::start(dir.path(), live, g).unwrap();
 
@@ -335,7 +335,7 @@ mod tests {
             "/nix/store/",
             &[("a", &[1]), ("b", &[2]), ("c", &[]), ("d", &[])],
         ));
-        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let live = Arc::new(LiveSet::new(g.len()));
         let dir = tempfile::tempdir().unwrap();
         let server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
         let sock = dir.path().join("gc-socket/socket");
@@ -360,7 +360,7 @@ mod tests {
     #[test]
     fn protect_blocks_until_pending_delete_finishes() {
         let g = Arc::new(graph("/nix/store/", &[("x", &[])]));
-        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let live = Arc::new(LiveSet::new(g.len()));
         let dir = tempfile::tempdir().unwrap();
         let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
         let sock = dir.path().join("gc-socket/socket");
@@ -394,7 +394,7 @@ mod tests {
             "/nix/store/",
             &[("a", &[2]), ("b", &[2]), ("c", &[])],
         ));
-        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let live = Arc::new(LiveSet::new(g.len()));
         let dir = tempfile::tempdir().unwrap();
         let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
         let sock = dir.path().join("gc-socket/socket");
@@ -431,7 +431,7 @@ mod tests {
     #[test]
     fn claim_nodes_partitions_and_blocks_protect() {
         let g = Arc::new(graph("/nix/store/", &[("a", &[]), ("b", &[])]));
-        let live = Arc::new(LiveSet::new(g.len(), HashSet::default()));
+        let live = Arc::new(LiveSet::new(g.len()));
         let dir = tempfile::tempdir().unwrap();
         let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
         let sock = dir.path().join("gc-socket/socket");
@@ -463,7 +463,7 @@ mod tests {
     #[test]
     fn unknown_path_protected_by_basename() {
         let g = Arc::new(graph("/nix/store/", &[]));
-        let live = Arc::new(LiveSet::new(0, HashSet::default()));
+        let live = Arc::new(LiveSet::new(0));
         let dir = tempfile::tempdir().unwrap();
         let _server = GcSocketServer::start(dir.path(), Arc::clone(&live), Arc::clone(&g)).unwrap();
         let sock = dir.path().join("gc-socket/socket");

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -123,6 +123,32 @@ fn main() -> Result<()> {
         bail!("--ensure-free cannot be combined with --dry-run");
     }
 
+    // Validate every time spec before any destructive work; a bad
+    // --keep-recent must not surface only after generations were deleted.
+    let delete_older_cutoff = args
+        .delete_older_than
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?;
+    let keep_recent_after = args
+        .keep_recent
+        .as_deref()
+        .map(profiles::parse_older_than)
+        .transpose()?
+        .map(|t| {
+            t.duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0)
+        });
+
+    if args.delete_old {
+        profiles::profile_dirs(&args.state_dir)
+            .par_iter()
+            .try_for_each(|dir| {
+                profiles::remove_old_generations(dir, delete_older_cutoff, args.dry_run)
+            })?;
+    }
+
     let max_freed = if let Some(target) = args.ensure_free {
         let avail = available_bytes(&args.store_dir)?;
         if avail >= target {
@@ -139,29 +165,6 @@ fn main() -> Result<()> {
     } else {
         None
     };
-
-    if args.delete_old {
-        let cutoff = args
-            .delete_older_than
-            .as_deref()
-            .map(profiles::parse_older_than)
-            .transpose()?;
-
-        profiles::profile_dirs(&args.state_dir)
-            .par_iter()
-            .try_for_each(|dir| profiles::remove_old_generations(dir, cutoff, args.dry_run))?;
-    }
-
-    let keep_recent_after = args
-        .keep_recent
-        .as_deref()
-        .map(profiles::parse_older_than)
-        .transpose()?
-        .map(|t| {
-            t.duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0)
-        });
 
     let mut store = db::NixDb::open(&args.store_dir, &args.state_dir)?;
     if let Some(v) = args.keep_outputs {

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -148,7 +148,17 @@ fn main() -> Result<()> {
         None
     };
 
-    let mut store = db::NixDb::open(&args.store_dir, &args.state_dir)?;
+    let mut store = if args.dry_run {
+        // No DB writes happen in a dry run; don't take write locks or
+        // flip the journal mode. A WAL database without its -shm/-wal
+        // sidecars can't be opened read-only, so fall back to read-write.
+        db::NixDb::open_read_only(&args.store_dir, &args.state_dir).or_else(|e| {
+            log::debug!("read-only open failed ({e:#}); retrying read-write");
+            db::NixDb::open(&args.store_dir, &args.state_dir)
+        })?
+    } else {
+        db::NixDb::open(&args.store_dir, &args.state_dir)?
+    };
     if let Some(v) = args.keep_outputs {
         store.keep_outputs = v;
     }

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -91,29 +91,8 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
     Ok(args)
 }
 
-/// Minimal stderr logger: `[LEVEL] message`. Level controlled by
-/// RUST_LOG=error|warn|info|debug|trace (default: info).
-struct StderrLogger(log::LevelFilter);
-
-impl log::Log for StderrLogger {
-    fn enabled(&self, m: &log::Metadata) -> bool {
-        m.level() <= self.0
-    }
-    fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) {
-            eprintln!("[{:5}] {}", record.level(), record.args());
-        }
-    }
-    fn flush(&self) {}
-}
-
 fn main() -> Result<()> {
-    let level = std::env::var("RUST_LOG")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(log::LevelFilter::Info);
-    log::set_boxed_logger(Box::new(StderrLogger(level))).unwrap();
-    log::set_max_level(level);
+    fast_nix_common::logging::init();
 
     let args = parse_args()?;
 

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -27,6 +27,9 @@ fn parse_size(s: &str) -> Result<u64> {
         _ => (s, 1),
     };
     let n: f64 = num.parse().with_context(|| format!("invalid size '{s}'"))?;
+    if !n.is_finite() || n < 0.0 || n * mult as f64 > u64::MAX as f64 {
+        bail!("size '{s}' is out of range");
+    }
     Ok((n * mult as f64) as u64)
 }
 
@@ -225,5 +228,9 @@ mod tests {
         assert_eq!(parse_size("1.5K").unwrap(), 1536);
         assert_eq!(parse_size(" 4M ").unwrap(), 4 * 1024 * 1024);
         assert!(parse_size("abc").is_err());
+        assert!(parse_size("-5G").is_err());
+        assert!(parse_size("inf").is_err());
+        assert!(parse_size("NaN").is_err());
+        assert!(parse_size("99999999999999999999G").is_err());
     }
 }

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -49,18 +49,18 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
     let mut pargs = pico_args::Arguments::from_vec(args);
 
     if pargs.contains("--help") {
-        eprintln!("Usage: fast-nix-gc [OPTIONS]");
-        eprintln!();
-        eprintln!("Options:");
-        eprintln!("  -d, --delete-old             Remove old profile generations");
-        eprintln!("      --delete-older-than SPEC  Delete generations older than SPEC (e.g. 30d)");
-        eprintln!("      --dry-run                 Show what would be done");
-        eprintln!("      --ensure-free SIZE           Free until SIZE is available (e.g. 50G)");
-        eprintln!("      --keep-recent SPEC        Keep paths registered within SPEC (e.g. 7d)");
-        eprintln!("      --keep-outputs BOOL       Override the keep-outputs nix.conf setting");
-        eprintln!("      --keep-derivations BOOL   Override the keep-derivations nix.conf setting");
-        eprintln!("      --store-dir PATH          Nix store directory [default: /nix/store]");
-        eprintln!("      --state-dir PATH          Nix state directory [default: /nix/var/nix]");
+        println!("Usage: fast-nix-gc [OPTIONS]");
+        println!();
+        println!("Options:");
+        println!("  -d, --delete-old              Remove old profile generations");
+        println!("      --delete-older-than SPEC  Delete generations older than SPEC (e.g. 30d)");
+        println!("      --dry-run                 Show what would be done");
+        println!("      --ensure-free SIZE        Free until SIZE is available (e.g. 50G)");
+        println!("      --keep-recent SPEC        Keep paths registered within SPEC (e.g. 7d)");
+        println!("      --keep-outputs BOOL       Override the keep-outputs nix.conf setting");
+        println!("      --keep-derivations BOOL   Override the keep-derivations nix.conf setting");
+        println!("      --store-dir PATH          Nix store directory [default: /nix/store]");
+        println!("      --state-dir PATH          Nix state directory [default: /nix/var/nix]");
         std::process::exit(0);
     }
 

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -39,7 +39,11 @@ fn available_bytes(path: &Path) -> Result<u64> {
 }
 
 fn parse_args() -> Result<Args> {
-    let mut pargs = pico_args::Arguments::from_env();
+    parse_args_from(std::env::args_os().skip(1).collect())
+}
+
+fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
+    let mut pargs = pico_args::Arguments::from_vec(args);
 
     if pargs.contains("--help") {
         eprintln!("Usage: fast-nix-gc [OPTIONS]");
@@ -61,7 +65,7 @@ fn parse_args() -> Result<Args> {
     let delete_old =
         pargs.contains("-d") || pargs.contains("--delete-old") || delete_older_than.is_some();
 
-    Ok(Args {
+    let args = Args {
         delete_old,
         delete_older_than,
         dry_run: pargs.contains("--dry-run"),
@@ -75,7 +79,13 @@ fn parse_args() -> Result<Args> {
         state_dir: pargs
             .opt_value_from_str("--state-dir")?
             .unwrap_or_else(|| PathBuf::from("/nix/var/nix")),
-    })
+    };
+    // A typo'd flag (e.g. --dry-rnu) must not silently run a destructive GC.
+    let rest = pargs.finish();
+    if !rest.is_empty() {
+        bail!("unexpected arguments: {rest:?}");
+    }
+    Ok(args)
 }
 
 /// Minimal stderr logger: `[LEVEL] message`. Level controlled by
@@ -184,7 +194,19 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_size;
+    use super::{parse_args_from, parse_size};
+
+    fn args(list: &[&str]) -> Vec<std::ffi::OsString> {
+        list.iter().map(|s| s.into()).collect()
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_arguments() {
+        assert!(parse_args_from(args(&["--dry-rnu"])).is_err());
+        assert!(parse_args_from(args(&["--dry-run", "extra"])).is_err());
+        let parsed = parse_args_from(args(&["--dry-run"])).unwrap();
+        assert!(parsed.dry_run);
+    }
 
     #[test]
     fn parse_size_units() {

--- a/crates/gc/src/profiles.rs
+++ b/crates/gc/src/profiles.rs
@@ -191,20 +191,27 @@ pub fn remove_old_generations(
     Ok(())
 }
 
+/// Directories scanned for profiles, mirroring nix-collect-garbage:
+/// the system profiles dir (recursed, so per-user is covered) and the
+/// invoking user's XDG state profiles dir. Never the home directory
+/// itself — remove_old_generations recurses, and treating arbitrary
+/// `*-N-link` symlinks under $HOME as generations would delete user data.
 pub fn profile_dirs(state_dir: &Path) -> BTreeSet<PathBuf> {
     let mut dirs = BTreeSet::new();
 
-    if let Ok(user) = std::env::var("USER") {
-        dirs.insert(state_dir.join("profiles/per-user").join(&user));
-    }
-
     dirs.insert(state_dir.join("profiles"));
 
-    if let Ok(home) = std::env::var("HOME") {
-        let default_profile = PathBuf::from(&home).join(".nix-profile");
-        if let Some(parent) = default_profile.parent() {
-            dirs.insert(parent.to_path_buf());
-        }
+    let xdg_state = std::env::var("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .ok()
+        .filter(|p| p.is_absolute())
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".local/state"))
+        });
+    if let Some(state_home) = xdg_state {
+        dirs.insert(state_home.join("nix/profiles"));
     }
 
     dirs
@@ -375,15 +382,16 @@ mod tests {
     }
 
     #[test]
-    fn profile_dirs_includes_state_and_user_paths() {
+    fn profile_dirs_includes_state_and_xdg_paths_but_not_home() {
         let state = Path::new("/var/state");
         let dirs = profile_dirs(state);
         assert!(dirs.contains(&state.join("profiles")));
-        if let Ok(user) = std::env::var("USER") {
-            assert!(dirs.contains(&state.join("profiles/per-user").join(user)));
-        }
         if let Ok(home) = std::env::var("HOME") {
-            assert!(dirs.contains(&PathBuf::from(home)));
+            // $HOME itself must never be scanned recursively.
+            assert!(!dirs.contains(&PathBuf::from(&home)));
+            if std::env::var("XDG_STATE_HOME").is_err() {
+                assert!(dirs.contains(&PathBuf::from(home).join(".local/state/nix/profiles")));
+            }
         }
     }
 

--- a/crates/gc/src/profiles.rs
+++ b/crates/gc/src/profiles.rs
@@ -116,15 +116,28 @@ fn delete_generations_older_than(profile: &Path, cutoff: SystemTime, dry_run: bo
     };
     let gens = find_generation_links(profile)?;
 
+    let mtime_of = |path: &Path| -> Option<SystemTime> {
+        let meta = fs::symlink_metadata(path).ok()?;
+        Some(meta.modified().unwrap_or(SystemTime::UNIX_EPOCH))
+    };
+
+    // Like Nix (profiles.cc deleteGenerationsOlderThan): keep the newest
+    // generation older than the cutoff. It was the active one at the
+    // requested point in time, and the user wants to be able to roll back
+    // to it.
+    let newest_older = gens
+        .iter()
+        .rev()
+        .find(|(path, _)| mtime_of(path).is_some_and(|t| t < cutoff))
+        .map(|(_, g)| *g);
+
     for (path, r#gen) in &gens {
-        if *r#gen == current {
+        if *r#gen == current || Some(*r#gen) == newest_older {
             continue;
         }
-        let meta = match fs::symlink_metadata(path) {
-            Ok(m) => m,
-            Err(_) => continue,
+        let Some(mtime) = mtime_of(path) else {
+            continue;
         };
-        let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
         if mtime < cutoff {
             if dry_run {
                 log::info!("would remove (old): {}", path.display());
@@ -313,15 +326,23 @@ mod tests {
             );
         }
 
-        // Cutoff exactly at gen 2's mtime: only gen 1 (strictly older) goes.
-        // Gen 4 is current and always kept.
+        // Cutoff exactly at gen 2's mtime: gen 1 is the only strictly
+        // older generation, and as the one active at the cutoff it is
+        // kept for rollback (Nix semantics). Nothing goes.
         let cutoff = base + Duration::from_secs(200);
         delete_generations_older_than(&profile, cutoff, true).unwrap();
         assert_eq!(existing_gens(dir.path()), vec![1, 2, 3, 4]);
         delete_generations_older_than(&profile, cutoff, false).unwrap();
-        assert_eq!(existing_gens(dir.path()), vec![2, 3, 4]);
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3, 4]);
 
-        // Cutoff after all gens: everything but current goes.
+        // Cutoff between gen 3 and 4: gens 1-3 are older, gen 3 was
+        // active at the cutoff and is kept; 1 and 2 go.
+        let cutoff = base + Duration::from_secs(350);
+        delete_generations_older_than(&profile, cutoff, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![3, 4]);
+
+        // Cutoff after all gens: the newest older one is the current
+        // generation itself, so everything else goes.
         delete_generations_older_than(&profile, base + Duration::from_secs(10_000), false).unwrap();
         assert_eq!(existing_gens(dir.path()), vec![4]);
     }

--- a/crates/gc/src/profiles.rs
+++ b/crates/gc/src/profiles.rs
@@ -55,7 +55,8 @@ fn find_generation_links(profile: &Path) -> Result<Vec<(PathBuf, u64)>> {
 fn current_generation(profile: &Path) -> Result<Option<u64>> {
     let target = match fs::read_link(profile) {
         Ok(t) => t,
-        Err(_) => return Ok(None),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).with_context(|| format!("readlink {}", profile.display())),
     };
     let name = target
         .file_name()
@@ -78,11 +79,20 @@ fn current_generation(profile: &Path) -> Result<Option<u64>> {
 }
 
 fn delete_old_generations(profile: &Path, dry_run: bool) -> Result<()> {
-    let current = current_generation(profile)?;
+    // Fail closed: if we cannot tell which generation is active (profile
+    // gone or pointing at something that isn't a generation link),
+    // deleting "all but current" would delete the active system too.
+    let Some(current) = current_generation(profile)? else {
+        log::warn!(
+            "cannot determine current generation of {}; skipping",
+            profile.display()
+        );
+        return Ok(());
+    };
     let gens = find_generation_links(profile)?;
 
     for (path, r#gen) in &gens {
-        if Some(*r#gen) == current {
+        if *r#gen == current {
             continue;
         }
         if dry_run {
@@ -96,11 +106,18 @@ fn delete_old_generations(profile: &Path, dry_run: bool) -> Result<()> {
 }
 
 fn delete_generations_older_than(profile: &Path, cutoff: SystemTime, dry_run: bool) -> Result<()> {
-    let current = current_generation(profile)?;
+    // Same fail-closed rule as delete_old_generations.
+    let Some(current) = current_generation(profile)? else {
+        log::warn!(
+            "cannot determine current generation of {}; skipping",
+            profile.display()
+        );
+        return Ok(());
+    };
     let gens = find_generation_links(profile)?;
 
     for (path, r#gen) in &gens {
-        if Some(*r#gen) == current {
+        if *r#gen == current {
             continue;
         }
         let meta = match fs::symlink_metadata(path) {
@@ -347,6 +364,21 @@ mod tests {
         if let Ok(home) = std::env::var("HOME") {
             assert!(dirs.contains(&PathBuf::from(home)));
         }
+    }
+
+    #[test]
+    fn unparseable_current_generation_deletes_nothing() {
+        // Profile pointing at a non-generation target: refusing to guess
+        // protects the active generation from "delete all but current".
+        let (dir, profile) = setup_profile(3, 2);
+        fs::remove_file(&profile).unwrap();
+        symlink("/nix/store/custom-env", &profile).unwrap();
+
+        delete_old_generations(&profile, false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
+
+        delete_generations_older_than(&profile, SystemTime::now(), false).unwrap();
+        assert_eq!(existing_gens(dir.path()), vec![1, 2, 3]);
     }
 
     #[test]

--- a/crates/gc/src/profiles.rs
+++ b/crates/gc/src/profiles.rs
@@ -86,7 +86,63 @@ fn current_generation(profile: &Path) -> Result<Option<u64>> {
     Ok(None)
 }
 
+/// Lock held while mutating a profile's generations, interoperable with
+/// Nix's PathLocks protocol (pathlocks.cc): flock(2) on "<profile>.lock",
+/// stale detection via a non-empty file, deletion marker on release.
+struct ProfileLock {
+    lock_path: PathBuf,
+    file: fs::File,
+}
+
+impl ProfileLock {
+    fn acquire(profile: &Path) -> Result<ProfileLock> {
+        use std::os::fd::AsRawFd;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut name = profile.file_name().unwrap_or_default().to_os_string();
+        name.push(".lock");
+        let lock_path = profile.with_file_name(name);
+        loop {
+            let file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(&lock_path)
+                .with_context(|| format!("opening {}", lock_path.display()))?;
+            loop {
+                if unsafe { nix::libc::flock(file.as_raw_fd(), nix::libc::LOCK_EX) } == 0 {
+                    break;
+                }
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() != Some(nix::libc::EINTR) {
+                    return Err(err).with_context(|| format!("locking {}", lock_path.display()));
+                }
+            }
+            // Stale check (Nix protocol): a non-empty lock file was marked
+            // and unlinked by its previous holder; retry on a fresh inode.
+            if file.metadata()?.len() != 0 {
+                continue;
+            }
+            return Ok(ProfileLock { lock_path, file });
+        }
+    }
+}
+
+impl Drop for ProfileLock {
+    fn drop(&mut self) {
+        use std::io::Write;
+        // Nix's deleteLockFile: write the deletion marker, then unlink.
+        // The flock itself is released when the fd closes.
+        let _ = self.file.write_all(b"d");
+        let _ = fs::remove_file(&self.lock_path);
+    }
+}
+
 fn delete_old_generations(profile: &Path, dry_run: bool) -> Result<()> {
+    // Serialize against nix-env/nixos-rebuild generation switches, which
+    // take the same lock (profiles.cc lockProfile).
+    let _lock = ProfileLock::acquire(profile)?;
     // Fail closed: if we cannot tell which generation is active (profile
     // gone or pointing at something that isn't a generation link),
     // deleting "all but current" would delete the active system too.
@@ -114,6 +170,7 @@ fn delete_old_generations(profile: &Path, dry_run: bool) -> Result<()> {
 }
 
 fn delete_generations_older_than(profile: &Path, cutoff: SystemTime, dry_run: bool) -> Result<()> {
+    let _lock = ProfileLock::acquire(profile)?;
     // Same fail-closed rule as delete_old_generations.
     let Some(current) = current_generation(profile)? else {
         log::warn!(
@@ -407,6 +464,20 @@ mod tests {
                 assert!(dirs.contains(&PathBuf::from(home).join(".local/state/nix/profiles")));
             }
         }
+    }
+
+    #[test]
+    fn profile_lock_acquire_release_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("system");
+        let lock_path = dir.path().join("system.lock");
+        {
+            let _lock = ProfileLock::acquire(&profile).unwrap();
+            assert!(lock_path.exists());
+        }
+        // Released locks are unlinked (Nix deleteLockFile protocol).
+        assert!(!lock_path.exists());
+        let _lock = ProfileLock::acquire(&profile).unwrap();
     }
 
     #[test]

--- a/crates/gc/src/profiles.rs
+++ b/crates/gc/src/profiles.rs
@@ -9,19 +9,27 @@ use std::time::{Duration, SystemTime};
 
 /// Parse Nix-style time specs like "30d", "4h", "2w", "1m".
 pub fn parse_older_than(spec: &str) -> Result<SystemTime> {
-    if spec.len() < 2 {
+    // Take the last *character*; a byte-based split_at would panic on
+    // multi-byte input like "30日".
+    let Some((idx, unit)) = spec.char_indices().last() else {
+        bail!("invalid time spec '{}', expected e.g. '30d'", spec);
+    };
+    let num_str = &spec[..idx];
+    if num_str.is_empty() {
         bail!("invalid time spec '{}', expected e.g. '30d'", spec);
     }
-    // split_at must land on a char boundary; suffix is always ASCII.
-    let (num_str, unit) = spec.split_at(spec.len() - 1);
     let num: u64 = num_str.parse().context("invalid number in time spec")?;
-    let secs = match unit {
-        "h" => num * 3600,
-        "d" => num * 86400,
-        "w" => num * 7 * 86400,
-        "m" => num * 30 * 86400,
+    let unit_secs = match unit {
+        'h' => 3600,
+        'd' => 86400,
+        'w' => 7 * 86400,
+        'm' => 30 * 86400,
         _ => bail!("unknown time unit '{}', use h/d/w/m", unit),
     };
+    let secs = num
+        .checked_mul(unit_secs)
+        .filter(|&s| s <= i64::MAX as u64)
+        .with_context(|| format!("time spec '{spec}' is out of range"))?;
     Ok(SystemTime::now() - Duration::from_secs(secs))
 }
 
@@ -247,6 +255,12 @@ mod tests {
         assert!(parse_older_than("d").is_err());
         assert!(parse_older_than("5x").is_err());
         assert!(parse_older_than("xd").is_err());
+        // Multi-byte unit must error, not panic on a char boundary.
+        assert!(parse_older_than("30日").is_err());
+        assert!(parse_older_than("日").is_err());
+        // Overflowing multiplication must error, not wrap.
+        assert!(parse_older_than("99999999999999999999d").is_err());
+        assert!(parse_older_than("9999999999999999999d").is_err());
     }
 
     #[test]

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -3,18 +3,21 @@
 
 use crate::HashSet;
 use crate::db::BasenameIndex;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
 /// Find all GC root node indices by walking gcroots/profiles directories
 /// and scanning running processes.
-pub fn find_roots(state_dir: &Path, store_dir: &Path, idx: &BasenameIndex) -> Vec<u32> {
+pub fn find_roots(state_dir: &Path, store_dir: &Path, idx: &BasenameIndex) -> Result<Vec<u32>> {
     let mut roots = HashSet::default();
     let store_prefix = store_dir.to_string_lossy().to_string();
 
+    // Errors here must abort the GC: silently dropping a roots directory
+    // (e.g. EACCES) would let the GC delete live paths.
     for dir in [state_dir.join("gcroots"), state_dir.join("profiles")] {
-        find_roots_in_dir(&dir, &store_prefix, idx, &mut roots);
+        find_roots_in_dir(&dir, &store_prefix, idx, &mut roots)
+            .with_context(|| format!("scanning roots in {}", dir.display()))?;
     }
 
     // Also scan running processes for runtime roots.
@@ -46,7 +49,7 @@ pub fn find_roots(state_dir: &Path, store_dir: &Path, idx: &BasenameIndex) -> Ve
         }
     }
 
-    roots.into_iter().collect()
+    Ok(roots.into_iter().collect())
 }
 
 fn find_roots_in_dir(
@@ -54,23 +57,31 @@ fn find_roots_in_dir(
     store_prefix: &str,
     idx: &BasenameIndex,
     roots: &mut HashSet<u32>,
-) {
+) -> Result<()> {
     let entries = match fs::read_dir(dir) {
         Ok(e) => e,
-        Err(_) => return,
+        // A missing roots dir contributes no roots; anything else (EACCES,
+        // EIO) hides an unknown number of roots and must fail the GC.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
     };
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading {}", dir.display()))?;
         let path = entry.path();
         let meta = match fs::symlink_metadata(&path) {
             Ok(m) => m,
-            Err(_) => continue,
+            // Entry removed while scanning (e.g. a stale auto link another
+            // process cleaned up) — not a root anymore.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e).with_context(|| format!("stat {}", path.display())),
         };
 
         if meta.file_type().is_symlink() {
             let target = match fs::read_link(&path) {
                 Ok(t) => t,
-                Err(_) => continue,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e).with_context(|| format!("readlink {}", path.display())),
             };
             let target_str = target.to_string_lossy();
 
@@ -116,7 +127,7 @@ fn find_roots_in_dir(
                 }
             }
         } else if meta.file_type().is_dir() {
-            find_roots_in_dir(&path, store_prefix, idx, roots);
+            find_roots_in_dir(&path, store_prefix, idx, roots)?;
         } else if meta.file_type().is_file() {
             // Regular file root (e.g. in auto-roots)
             let name = path.file_name().unwrap_or_default().to_string_lossy();
@@ -126,6 +137,7 @@ fn find_roots_in_dir(
             }
         }
     }
+    Ok(())
 }
 
 /// Extract the top-level store path from a potentially deeper path.
@@ -640,7 +652,11 @@ pub fn find_temp_roots(state_dir: &Path) -> Result<HashSet<String>> {
         let path = entry.path();
         let f = match fs::OpenOptions::new().read(true).write(true).open(&path) {
             Ok(f) => f,
-            Err(_) => continue,
+            // Owner exited and the file was cleaned up meanwhile.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            // Anything else (EACCES, EIO) hides live roots: deleting their
+            // targets would yank paths from under a running builder.
+            Err(e) => return Err(e).with_context(|| format!("opening {}", path.display())),
         };
 
         // Owner holds a write lock while alive; if we can take it, it's stale.
@@ -651,10 +667,7 @@ pub fn find_temp_roots(state_dir: &Path) -> Result<HashSet<String>> {
             continue;
         }
 
-        let contents = match fs::read(&path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
+        let contents = fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
 
         // Each path is NUL-terminated. A trailing run without a NUL is a
         // partial write from a live builder — drop it.

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -669,10 +669,18 @@ pub fn find_temp_roots(state_dir: &Path) -> Result<HashSet<String>> {
         };
 
         // Owner holds a write lock while alive; if we can take it, it's stale.
-        if let Ok(_lock) = nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+        if let Ok(mut lock) =
+            nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockExclusiveNonblock)
+        {
             log::info!("removing stale temporary roots file {}", path.display());
             fs::remove_file(&path).ok();
-            // _lock dropped here, releasing flock after unlink
+            // Nix protocol (gc.cc): write "d" after unlinking so a client
+            // that re-acquires its fd sees the marker and recreates the
+            // file instead of writing roots into an unlinked inode the GC
+            // will never read.
+            use std::io::Write;
+            let _ = lock.write_all(b"d");
+            // lock dropped here, releasing flock after unlink
             continue;
         }
 
@@ -791,11 +799,23 @@ mod tests {
         fs::write(dir.join(".keep"), b"junk").unwrap();
         fs::write(dir.join("notapid"), format!("/nix/store/{HASH}-junk\0")).unwrap();
 
+        // Keep an fd on the stale file to observe the "d" marker.
+        let stale_fd = fs::File::open(&stale).unwrap();
+
         let roots = find_temp_roots(tmp.path()).unwrap();
         assert!(roots.contains(&sp1));
         assert!(roots.contains(&sp2));
         assert_eq!(roots.len(), 2, "{roots:?}");
         assert!(!stale.exists(), "stale temp roots file removed");
+        // Nix clients detect deletion by reading back a "d" marker.
+        {
+            use std::io::{Read, Seek};
+            let mut f = stale_fd;
+            f.seek(std::io::SeekFrom::Start(0)).unwrap();
+            let mut b = [0u8; 1];
+            f.read_exact(&mut b).unwrap();
+            assert_eq!(&b, b"d", "missing deletion marker");
+        }
         assert!(dir.join(".keep").exists());
         assert!(dir.join("notapid").exists());
     }

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -343,7 +343,9 @@ mod runtime_roots {
     const PROC_PIDLISTFDS: c_int = 1;
     const PROC_PIDVNODEPATHINFO: c_int = 9;
     const PROC_PIDREGIONPATHINFO: c_int = 8;
-    const PROC_PIDFDVNODEPATHINFO: c_int = 1;
+    // proc_info.h: PROC_PIDFDVNODEINFO is 1 and carries no path;
+    // PATHINFO is 2.
+    const PROC_PIDFDVNODEPATHINFO: c_int = 2;
     const PROX_FDTYPE_VNODE: u32 = 1;
     const PROC_PIDPATHINFO_MAXSIZE: usize = 4 * 1024;
     const MAXPATHLEN: usize = 1024;

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -103,9 +103,18 @@ fn find_roots_in_dir(
                 };
                 // metadata() (stat, follows) returns ENOENT for dangling
                 // links and ELOOP for cycles — both are "target gone".
-                if fs::metadata(&abs_target).is_err() {
-                    let auto_dir = dir.to_string_lossy();
-                    if auto_dir.contains("gcroots/auto") {
+                // Any other error (EACCES, EIO) says nothing about the
+                // target's existence: removing the root then would let the
+                // GC delete a live path.
+                if let Err(e) = fs::metadata(&abs_target) {
+                    let target_gone = e.kind() == std::io::ErrorKind::NotFound
+                        || e.raw_os_error() == Some(nix::errno::Errno::ELOOP as i32);
+                    if !target_gone {
+                        return Err(e).with_context(|| format!("stat {}", abs_target.display()));
+                    }
+                    // Component match, not substring: "gcroots/automatic"
+                    // must not qualify.
+                    if dir.ends_with("gcroots/auto") {
                         log::info!("removing stale link {}", path.display());
                         fs::remove_file(&path).ok();
                     }

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -970,3 +970,48 @@ fn gc_fails_when_roots_dir_is_unreadable() {
     );
     assert!(lib.path.exists() && store.in_db(&lib), "live path deleted");
 }
+
+#[test]
+fn gc_keeps_auto_root_with_unreadable_target() {
+    use std::os::unix::fs::PermissionsExt;
+    if nix::unistd::geteuid().is_root() {
+        return; // root bypasses permission checks
+    }
+    // An EACCES on the indirect target says nothing about its existence;
+    // the auto link must survive and the GC must fail closed.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    let private = store.dir.path().join("private");
+    fs::create_dir_all(&private).unwrap();
+    let user_link = private.join("result");
+    std::os::unix::fs::symlink(&lib.path, &user_link).unwrap();
+    std::os::unix::fs::symlink(&user_link, auto.join("x0")).unwrap();
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let out = store.run_gc(&[]);
+
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(!out.status.success(), "GC must fail closed");
+    assert!(
+        auto.join("x0").symlink_metadata().is_ok(),
+        "auto root removed"
+    );
+    assert!(lib.path.exists());
+}
+
+#[test]
+fn gc_removes_dangling_auto_root() {
+    let store = TestStore::new();
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    std::os::unix::fs::symlink(store.dir.path().join("gone"), auto.join("x1")).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(
+        auto.join("x1").symlink_metadata().is_err(),
+        "dangling auto root must be removed"
+    );
+}

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -1052,3 +1052,32 @@ fn gc_keeps_lock_file_of_active_build() {
     assert!(!stale_lock.exists(), "stale lock file kept");
     drop(lock);
 }
+
+#[test]
+fn gc_deletes_non_utf8_store_entry() {
+    use std::os::unix::ffi::OsStrExt;
+    let store = TestStore::new();
+    let raw = std::ffi::OsStr::from_bytes(b"junk-\xff\xfe-entry");
+    let path = store.store_dir.join(raw);
+    fs::write(&path, "garbage").unwrap();
+
+    let out = store.run_gc_ok(&[]);
+
+    assert!(
+        path.symlink_metadata().is_err(),
+        "non-UTF-8 garbage entry must be deleted"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("1 store paths deleted"), "stdout: {stdout}");
+}
+
+#[test]
+fn gc_does_not_hang_on_tmp_fifo() {
+    let store = TestStore::new();
+    let fifo = store.store_dir.join("tmp-fifo");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o644).unwrap()).unwrap();
+
+    // Must terminate (no blocking open) and remove the FIFO.
+    store.run_gc_ok(&[]);
+    assert!(fifo.symlink_metadata().is_err(), "FIFO not collected");
+}

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -291,6 +291,7 @@ fn gc_cleans_unused_links_only_when_not_dry_run() {
     let pkg = store.add_path("linked", 100);
     store.add_root("linked-root", &pkg);
     fs::hard_link(&shared_link, pkg.path.join("shared")).unwrap();
+    fs::hard_link(&shared_link, pkg.path.join("shared2")).unwrap();
 
     store.run_gc_ok(&["--dry-run"]);
     assert!(dead_link.exists(), "dry run must not clean links");
@@ -298,7 +299,8 @@ fn gc_cleans_unused_links_only_when_not_dry_run() {
     let out = store.run_gc_ok(&[]);
     assert!(!dead_link.exists(), "unreferenced link removed");
     assert!(shared_link.exists(), "referenced link kept");
-    // "referenced" is 10 bytes with nlink 2: savings = (2-1)*10.
+    // "referenced" is 10 bytes with nlink 3 (one .links entry + two store
+    // copies): dedup saves (3-2)*10 over independent copies.
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("currently saving 10 bytes"),

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -946,3 +946,27 @@ fn gc_refuses_store_dir_mismatching_db() {
     );
     assert!(lib.path.exists() && store.in_db(&lib));
 }
+
+#[test]
+fn gc_fails_when_roots_dir_is_unreadable() {
+    use std::os::unix::fs::PermissionsExt;
+    if nix::unistd::geteuid().is_root() {
+        // Root bypasses permission checks; cannot simulate EACCES.
+        return;
+    }
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    let sub = store.state_dir.join("gcroots/sub");
+    fs::create_dir_all(&sub).unwrap();
+    std::os::unix::fs::symlink(&lib.path, sub.join("lib-root")).unwrap();
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let out = store.run_gc(&[]);
+
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        !out.status.success(),
+        "GC must fail closed when a roots dir is unreadable"
+    );
+    assert!(lib.path.exists() && store.in_db(&lib), "live path deleted");
+}

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -899,3 +899,50 @@ fn gc_keeps_ca_deriver_via_build_trace() {
     );
     assert!(!trash.path.exists());
 }
+
+#[test]
+fn gc_store_dir_trailing_slash_is_normalized() {
+    // "--store-dir /path/" must behave like "--store-dir /path"; an
+    // unnormalized prefix would make every DB path look dead.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    store.add_root("lib-root", &lib);
+
+    let out = Command::new(env!("CARGO_BIN_EXE_fast-nix-gc"))
+        .arg("--store-dir")
+        .arg(format!("{}/", store.store_dir.display()))
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(lib.path.exists() && store.in_db(&lib), "live path deleted");
+}
+
+#[test]
+fn gc_refuses_store_dir_mismatching_db() {
+    // A store dir that matches no DB path means the DB belongs to a
+    // different store; deleting "garbage" would wipe everything.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    store.add_root("lib-root", &lib);
+
+    let other = store.dir.path().join("other-store");
+    fs::create_dir_all(&other).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_fast-nix-gc"))
+        .arg("--store-dir")
+        .arg(&other)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "GC must refuse a mismatched store dir"
+    );
+    assert!(lib.path.exists() && store.in_db(&lib));
+}

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -1015,3 +1015,40 @@ fn gc_removes_dangling_auto_root() {
         "dangling auto root must be removed"
     );
 }
+
+#[test]
+fn gc_keeps_lock_file_of_active_build() {
+    let store = TestStore::new();
+
+    // Builder holds a temp root for the path it is building; its .lock
+    // sibling (not in the DB) shares the hash part and must survive.
+    let alive = store.add_path("being-built", 100);
+    let basename = alive
+        .full
+        .strip_prefix(&format!("{}/", store.store_dir.display()))
+        .unwrap();
+    let lock_file = store.store_dir.join(format!("{basename}.lock"));
+    fs::write(&lock_file, "").unwrap();
+    // Unrelated stale lock file: still garbage.
+    let stale_lock = store
+        .store_dir
+        .join(format!("{}-stale.lock", fake_hash("stale")));
+    fs::write(&stale_lock, "").unwrap();
+
+    let tmp_file = store.state_dir.join("temproots/4242");
+    let mut data = alive.full.clone().into_bytes();
+    data.push(0);
+    fs::write(&tmp_file, &data).unwrap();
+    let f = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&tmp_file)
+        .unwrap();
+    let lock = nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockSharedNonblock).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(lock_file.exists(), "active build's .lock file deleted");
+    assert!(!stale_lock.exists(), "stale lock file kept");
+    drop(lock);
+}

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -731,24 +731,24 @@ fn gc_keeps_deriver_of_alive_path() {
 }
 
 #[test]
-fn gc_keeps_ca_deriver_via_derivation_outputs() {
+fn gc_deletes_drv_when_output_deriver_is_unset() {
     let store = TestStore::new();
 
-    // Content-addressed derivation: deriver field is NOT set on the output,
-    // but DerivationOutputs maps drv -> output path.
+    // Output with NULL deriver but a DerivationOutputs row: Nix's
+    // keep-derivations pins drvs only via ValidPaths.deriver (gc.cc
+    // requires queryPathInfo(out)->deriver == drv), so the drv is garbage.
     let drv = store.add_path("ca-pkg.drv", 50);
     let out = store.add_path("ca-pkg", 200);
-    // No set_deriver — simulates CA where ValidPaths.deriver is NULL.
     store.add_drv_output(&drv, "out", &out);
     store.add_root("ca-out-root", &out);
-    let trash = store.add_path("trash", 100);
 
     store.run_gc_ok(&[]);
 
-    // keep-derivations: CA output keeps its .drv alive via DerivationOutputs.
     assert!(out.path.exists(), "output deleted");
-    assert!(drv.path.exists(), "CA deriver deleted despite alive output");
-    assert!(!trash.path.exists());
+    assert!(
+        !drv.path.exists(),
+        "drv kept despite no alive path naming it as deriver"
+    );
 }
 
 #[test]
@@ -882,24 +882,28 @@ fn gc_keeps_ca_output_via_build_trace() {
 }
 
 #[test]
-fn gc_keeps_ca_deriver_via_build_trace() {
-    // Alive CA output should keep its drv alive via BuildTraceV3.
+fn gc_keeps_ca_deriver_via_deriver_field_not_build_trace() {
+    // An alive CA output keeps its drv only through ValidPaths.deriver,
+    // like Nix; a BuildTraceV3 row alone must not pin the drv (the
+    // output may have been rebuilt by a newer drv since).
     let store = TestStore::new();
 
+    let stale_drv = store.add_path("dyn-pkg-old.drv", 50);
     let drv = store.add_path("dyn-pkg.drv", 50);
     let out = store.add_path("dyn-pkg-out", 200);
+    store.add_build_trace(&stale_drv, "out", &out);
     store.add_build_trace(&drv, "out", &out);
+    store.set_deriver(&out, &drv);
     store.add_root("out-root", &out);
-    let trash = store.add_path("trash", 100);
 
     store.run_gc_ok(&[]);
 
     assert!(out.path.exists(), "output deleted");
+    assert!(drv.path.exists(), "deriver deleted despite alive output");
     assert!(
-        drv.path.exists(),
-        "CA deriver deleted despite alive output (BuildTraceV3)"
+        !stale_drv.path.exists(),
+        "stale drv kept via BuildTraceV3 alone"
     );
-    assert!(!trash.path.exists());
 }
 
 #[test]

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -1083,3 +1083,21 @@ fn gc_does_not_hang_on_tmp_fifo() {
     store.run_gc_ok(&[]);
     assert!(fifo.symlink_metadata().is_err(), "FIFO not collected");
 }
+
+#[test]
+fn gc_removes_reserved_space_file_and_creates_private_lock() {
+    use std::os::unix::fs::PermissionsExt;
+    let store = TestStore::new();
+    let reserved = store.state_dir.join("db/reserved");
+    fs::write(&reserved, vec![b'X'; 1024]).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(!reserved.exists(), "reserved space file must be freed");
+    let mode = fs::metadata(store.state_dir.join("gc.lock"))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600, "gc.lock must not be lockable by other users");
+}

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -1105,3 +1105,122 @@ fn gc_removes_reserved_space_file_and_creates_private_lock() {
         & 0o777;
     assert_eq!(mode, 0o600, "gc.lock must not be lockable by other users");
 }
+
+/// Connect to the gc-socket during the early window (before the graph is
+/// loaded), register a root, and let the GC continue.
+fn run_gc_with_early_root(
+    store: &TestStore,
+    root: &str,
+    extra_args: &[&str],
+) -> std::process::Output {
+    use std::io::{Read, Write};
+
+    let fifo = store.dir.path().join("sync-early");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o600).unwrap()).unwrap();
+
+    let child = Command::new(env!("CARGO_BIN_EXE_fast-nix-gc"))
+        .arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .args(extra_args)
+        .env("_FAST_NIX_GC_TEST_SYNC_EARLY", &fifo)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Blocks until the GC reached the sync point: lock held, early
+    // socket up, graph not loaded yet.
+    let fifo_w = fs::OpenOptions::new().write(true).open(&fifo).unwrap();
+
+    let sock = store.state_dir.join("gc-socket/socket");
+    let mut conn = std::os::unix::net::UnixStream::connect(&sock)
+        .expect("gc-socket must be served before the graph is loaded");
+    conn.write_all(format!("{root}\n").as_bytes()).unwrap();
+    let mut ack = [0u8; 1];
+    conn.read_exact(&mut ack).unwrap();
+    assert_eq!(ack, [b'1'], "early root must be acked immediately");
+
+    drop(fifo_w); // release the GC
+    let out = child.wait_with_output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+#[test]
+fn gc_socket_serves_before_graph_load_and_keeps_early_roots() {
+    let store = TestStore::new();
+    let dead = store.add_path("now-needed", 100);
+    let trash = store.add_path("trash", 100);
+
+    run_gc_with_early_root(&store, &dead.full, &[]);
+
+    assert!(
+        dead.path.exists() && store.in_db(&dead),
+        "early-socket root was deleted"
+    );
+    assert!(!trash.path.exists());
+}
+
+#[test]
+fn gc_dry_run_serves_socket_and_honors_roots() {
+    let store = TestStore::new();
+    let dead = store.add_path("now-needed", 100);
+    let trash = store.add_path("trash", 100);
+
+    let out = run_gc_with_early_root(&store, &dead.full, &["--dry-run"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains(&dead.full),
+        "protected path reported as dead: {stdout}"
+    );
+    assert!(stdout.contains(&trash.full), "stdout: {stdout}");
+    assert!(dead.path.exists() && trash.path.exists());
+}
+
+#[test]
+fn gc_socket_root_mid_gc_keeps_path_and_deletes_rest() {
+    // Mirror of the NixOS test's gc-socket phase: while the delete loop is
+    // blocked on _FAST_NIX_GC_TEST_SYNC, protect one dead path over the
+    // socket; after release, it survives and the other dead path is gone.
+    use std::io::{Read, Write};
+    let store = TestStore::new();
+    let saved = store.add_path("saved", 10);
+    let other = store.add_path("other", 10);
+
+    let fifo = store.dir.path().join("sync.fifo");
+    nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::from_bits(0o600).unwrap()).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_fast-nix-gc"))
+        .arg("--store-dir")
+        .arg(&store.store_dir)
+        .arg("--state-dir")
+        .arg(&store.state_dir)
+        .env("_FAST_NIX_GC_TEST_SYNC", &fifo)
+        .spawn()
+        .unwrap();
+
+    let fifo_w = fs::OpenOptions::new().write(true).open(&fifo).unwrap();
+
+    let sock = store.state_dir.join("gc-socket/socket");
+    let mut conn = std::os::unix::net::UnixStream::connect(&sock).unwrap();
+    conn.write_all(format!("{}\n", saved.full).as_bytes())
+        .unwrap();
+    let mut ack = [0u8; 1];
+    conn.read_exact(&mut ack).unwrap();
+    assert_eq!(ack, [b'1']);
+
+    drop(fifo_w);
+    let status = child.wait().unwrap();
+    assert!(status.success());
+
+    assert!(saved.path.exists() && store.in_db(&saved), "saved deleted");
+    assert!(!other.path.exists(), "other survived");
+    assert!(!store.in_db(&other));
+}

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -145,7 +145,7 @@ impl Drop for ParentRestore<'_> {
     fn drop(&mut self) {
         if self.active {
             let _ = fs::set_permissions(self.dir, fs::Permissions::from_mode(0o555));
-            let _ = filetime_set_zero(self.dir);
+            let _ = set_mtime_to_one(self.dir);
         }
     }
 }
@@ -165,7 +165,7 @@ fn dir_mutex(dir: &Path) -> &'static std::sync::Mutex<()> {
     &pool[h as usize % SHARDS]
 }
 
-fn filetime_set_zero(path: &Path) -> std::io::Result<()> {
+fn set_mtime_to_one(path: &Path) -> std::io::Result<()> {
     use nix::sys::stat::{UtimensatFlags, utimensat};
     use nix::sys::time::TimeSpec;
     utimensat(

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -22,6 +22,8 @@ pub struct Stats {
     pub bytes_freed: AtomicU64,
     pub files_skipped: AtomicU64,
     pub link_enospc: AtomicU64,
+    /// Files or paths skipped because of I/O errors (logged, not fatal).
+    pub errors: AtomicU64,
 }
 
 pub struct Options {
@@ -368,11 +370,13 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
 
     let producer = {
         let known = known_inodes.clone();
+        let stats = stats.clone();
         tokio::spawn(async move {
             let mut walks: JoinSet<Result<()>> = JoinSet::new();
             for store_path in paths {
                 let permit = walk_sem.clone().acquire_owned().await?;
                 let known = known.clone();
+                let stats = stats.clone();
                 let tx = file_tx.clone();
                 let store_path = store_path.to_absolute_path(&store_dir_typed);
                 walks.spawn(async move {
@@ -418,7 +422,18 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
                             Ok(out)
                         },
                     )
-                    .await??;
+                    .await?;
+                    // One unreadable path must not abort the whole run;
+                    // log and dedup the rest, like nix-store --optimise.
+                    let files = match files {
+                        Ok(f) => f,
+                        Err(e) => {
+                            log::warn!("skipping store path: {e:#}");
+                            stats.errors.fetch_add(1, Ordering::Relaxed);
+                            drop(permit);
+                            return Ok(());
+                        }
+                    };
                     // Walk done; release the slot before potentially
                     // blocking on a full channel.
                     drop(permit);
@@ -447,8 +462,13 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
         let opts = opts.clone();
         let stats = stats.clone();
         tasks.spawn(async move {
+            let stats2 = stats.clone();
             let _p = permit;
-            optimise_file(file, meta, links_dir, store_dir, opts, stats).await
+            if let Err(e) = optimise_file(file, meta, links_dir, store_dir, opts, stats).await {
+                log::warn!("skipping file: {e:#}");
+                stats2.errors.fetch_add(1, Ordering::Relaxed);
+            }
+            Ok(())
         });
         while let Some(res) = tasks.try_join_next() {
             res??;
@@ -489,6 +509,10 @@ pub fn cli_main() -> Result<()> {
     let enospc = stats.link_enospc.load(Ordering::Relaxed);
     if enospc > 0 {
         log::warn!("could not create {enospc} link(s): no space left on device");
+    }
+    let errors = stats.errors.load(Ordering::Relaxed);
+    if errors > 0 {
+        log::warn!("skipped {errors} file(s)/path(s) due to errors");
     }
     let linked = stats.files_linked.load(Ordering::Relaxed);
     let freed = stats.bytes_freed.load(Ordering::Relaxed);
@@ -532,6 +556,9 @@ fn parse_args() -> Result<Options> {
         .opt_value_from_str("--jobs")?
         .or(p.opt_value_from_str("-j")?)
     {
+        if v == 0 {
+            bail!("--jobs must be at least 1");
+        }
         opts.jobs = v;
     }
     if let Some(v) = p.opt_value_from_str("--store-dir")? {
@@ -849,6 +876,31 @@ mod tests {
         let stats = optimise_store(run_opts(&store, &state)).await.unwrap();
         assert_eq!(stats.files_linked.load(Ordering::Relaxed), 0);
         assert_eq!(stats.files_skipped.load(Ordering::Relaxed), 1);
+        unlock(&p1);
+        unlock(&p2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unreadable_path_is_skipped_not_fatal() {
+        if nix::unistd::geteuid().is_root() {
+            return; // root bypasses permission checks
+        }
+        let tmp = tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&store).unwrap();
+        let bad = mk_store_path(&store, "llllllllllllllllllllllllllllllll-l", CONTENT);
+        let p1 = mk_store_path(&store, "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm-m", CONTENT);
+        let p2 = mk_store_path(&store, "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn-n", CONTENT);
+        fs::set_permissions(&bad, fs::Permissions::from_mode(0o000)).unwrap();
+        mk_db(&state, &[&bad, &p1, &p2]);
+
+        let stats = optimise_store(run_opts(&store, &state)).await.unwrap();
+
+        // The unreadable path is skipped; the other two still dedup.
+        assert_eq!(stats.errors.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 1);
+        unlock(&bad);
         unlock(&p1);
         unlock(&p2);
     }

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -207,7 +207,7 @@ async fn optimise_file(
         stats.files_skipped.fetch_add(1, Ordering::Relaxed);
         return Ok(());
     }
-    if ft.is_file() && meta.len() < opts.min_size {
+    if meta.len() < opts.min_size {
         stats.files_skipped.fetch_add(1, Ordering::Relaxed);
         return Ok(());
     }

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -546,16 +546,17 @@ pub fn cli_main() -> Result<()> {
 fn parse_args() -> Result<Options> {
     let mut p = pico_args::Arguments::from_env();
     if p.contains("--help") {
-        eprintln!("Usage: fast-nix-optimise [OPTIONS]");
-        eprintln!();
-        eprintln!("Options:");
-        eprintln!("      --dry-run             Show what would be done");
-        eprintln!("      --min-size BYTES      Skip files smaller than BYTES");
-        eprintln!("  -j, --jobs N              Concurrency [default: num CPUs]");
-        eprintln!("      --store-dir PATH      Nix store directory [default: /nix/store]");
-        eprintln!("      --state-dir PATH      Nix state directory [default: /nix/var/nix]");
+        println!("Usage: fast-nix-optimise [OPTIONS]");
+        println!();
+        println!("Options:");
+        println!("      --dry-run             Show what would be done");
+        println!("      --min-size BYTES      Skip files smaller than BYTES");
+        println!("  -j, --jobs N              Concurrency [default: num CPUs]");
+        println!("      --store-dir PATH      Nix store directory [default: /nix/store]");
+        println!("      --state-dir PATH      Nix state directory [default: /nix/var/nix]");
         std::process::exit(0);
     }
+
     let mut opts = Options {
         dry_run: p.contains("--dry-run"),
         ..Options::default()

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -6,7 +6,6 @@ use fast_nix_common::{
     HashSet, db::NixDb, format_size, make_store_writable, unshare_mount_namespace,
 };
 use harmonia_store_core::store_path::StoreDir;
-use nix::fcntl::{Flock, FlockArg};
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
@@ -318,31 +317,6 @@ fn libc_emlink() -> i32 {
     nix::errno::Errno::EMLINK as i32
 }
 
-/// Hold gc.lock shared for the whole run so the GC (which takes it
-/// exclusive) cannot delete paths from under us.
-fn shared_gc_lock(state_dir: &Path) -> Result<Flock<fs::File>> {
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_path = state_dir.join("gc.lock");
-    // 0600 like Nix's openLockFile.
-    let f = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .mode(0o600)
-        .open(&lock_path)
-        .with_context(|| format!("opening {}", lock_path.display()))?;
-    match Flock::lock(f, FlockArg::LockSharedNonblock) {
-        Ok(l) => Ok(l),
-        Err((f, _)) => {
-            log::info!("waiting for garbage collector to finish...");
-            Flock::lock(f, FlockArg::LockShared)
-                .map_err(|(_, e)| e)
-                .context("acquiring shared gc.lock")
-        }
-    }
-}
-
 pub async fn optimise_store(opts: Options) -> Result<Stats> {
     let links_dir = opts.store_dir.join(".links");
     if !opts.dry_run {
@@ -351,12 +325,21 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
             .with_context(|| format!("creating {}", links_dir.display()))?;
     }
 
-    let _gc_lock = shared_gc_lock(&opts.state_dir)?;
+    // Like Nix's optimiseStore: register each path as a temp root right
+    // before working on it instead of holding gc.lock shared for the
+    // whole (potentially hours-long) run, which would block every GC.
+    // Dry runs touch nothing and take no roots.
+    let mut temp_roots = if opts.dry_run {
+        None
+    } else {
+        Some(fast_nix_common::temp_roots::TempRoots::create(
+            &opts.state_dir,
+        )?)
+    };
 
     let db = NixDb::open(&opts.store_dir, &opts.state_dir)?;
     let store_dir_typed: StoreDir = db.store_dir_typed()?;
     let paths = db.valid_store_paths()?;
-    drop(db);
     log::info!("optimising {} store paths", paths.len());
 
     let t0 = std::time::Instant::now();
@@ -392,6 +375,16 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
                 let stats = stats.clone();
                 let tx = file_tx.clone();
                 let store_path = store_path.to_absolute_path(&store_dir_typed);
+                if let Some(tr) = temp_roots.as_mut() {
+                    let path_str = store_path.to_string_lossy();
+                    tr.add(&path_str)
+                        .with_context(|| format!("registering temp root {path_str}"))?;
+                    // A GC running before our registration may have deleted
+                    // the path (Nix: "path was GC'ed, probably").
+                    if !db.is_valid_path(&path_str)? {
+                        continue;
+                    }
+                }
                 walks.spawn(async move {
                     let files = tokio::task::spawn_blocking(
                         move || -> Result<Vec<(PathBuf, fs::Metadata)>> {
@@ -467,7 +460,10 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
             while let Some(res) = walks.join_next().await {
                 res??;
             }
-            anyhow::Ok(())
+            // Hand the temp roots back so they outlive the link workers,
+            // not just the walks: dropping them here would release the
+            // temproots flock while files are still being replaced.
+            anyhow::Ok(temp_roots)
         })
     };
 
@@ -491,10 +487,11 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
         }
     }
 
-    producer.await??;
+    let temp_roots = producer.await??;
     while let Some(res) = tasks.join_next().await {
         res??;
     }
+    drop(temp_roots);
 
     Ok(Arc::into_inner(stats).expect("all tasks joined"))
 }
@@ -875,6 +872,38 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn registers_temp_roots_for_optimised_paths() {
+        let tmp = tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let state = tmp.path().join("state");
+        fs::create_dir_all(&store).unwrap();
+        let p1 = mk_store_path(&store, "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq-q", CONTENT);
+        let p2 = mk_store_path(&store, "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr-r", CONTENT);
+        mk_db(&state, &[&p1, &p2]);
+
+        optimise_store(run_opts(&store, &state)).await.unwrap();
+
+        // Every optimised path was registered in our temproots file, so a
+        // concurrent GC would not have deleted it mid-replace.
+        let roots = fs::read(state.join("temproots").join(std::process::id().to_string())).unwrap();
+        let roots = String::from_utf8(roots).unwrap();
+        assert!(roots.contains(p1.to_str().unwrap()), "{roots}");
+        assert!(roots.contains(p2.to_str().unwrap()), "{roots}");
+        unlock(&p1);
+        unlock(&p2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dry_run_takes_no_temp_roots() {
+        let (_stats, _f1, _f2, tmp) = run_two_identical(0, true).await;
+        let tr = tmp
+            .path()
+            .join("state/temproots")
+            .join(std::process::id().to_string());
+        assert!(!tr.exists(), "dry run must not write temp roots");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn unreadable_path_is_skipped_not_fatal() {
         if nix::unistd::geteuid().is_root() {
             return; // root bypasses permission checks
@@ -897,20 +926,5 @@ mod tests {
         unlock(&bad);
         unlock(&p1);
         unlock(&p2);
-    }
-
-    #[test]
-    fn shared_gc_lock_blocks_exclusive() {
-        use nix::fcntl::{Flock, FlockArg};
-        let tmp = tempdir().unwrap();
-        let _shared = shared_gc_lock(tmp.path()).unwrap();
-        // GC takes the lock exclusive; while we hold it shared, the
-        // exclusive non-blocking attempt must fail.
-        let f = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(tmp.path().join("gc.lock"))
-            .unwrap();
-        assert!(Flock::lock(f, FlockArg::LockExclusiveNonblock).is_err());
     }
 }

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -96,7 +96,11 @@ fn replace_with_link(path: &Path, link_path: &Path, store_dir: &Path) -> Result<
 
     let restore = scopeguard(parent, must_toggle);
 
-    let tmp = parent.join(format!(
+    // The temp link lives in the store root, like Nix's makeTempPath
+    // (optimise-store.cc): a crash must leave the stray file *outside* the
+    // store path, where the next GC removes it as unknown-on-disk. Inside
+    // the path it would permanently corrupt the path's NAR contents.
+    let tmp = store_dir.join(format!(
         ".tmp-link-{}-{}",
         std::process::id(),
         rand_suffix()

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -24,6 +24,10 @@ pub struct Stats {
     pub link_enospc: AtomicU64,
     /// Files or paths skipped because of I/O errors (logged, not fatal).
     pub errors: AtomicU64,
+    /// Dry-run only: hashes whose .links entry would be created by this
+    /// run. The first file of a hash becomes the canonical entry and
+    /// frees nothing; only subsequent duplicates count.
+    dry_run_links: std::sync::Mutex<HashSet<String>>,
 }
 
 pub struct Options {
@@ -220,8 +224,13 @@ async fn optimise_file(
         }
         Err(_) => {
             if opts.dry_run {
-                stats.files_linked.fetch_add(1, Ordering::Relaxed);
-                stats.bytes_freed.fetch_add(meta.len(), Ordering::Relaxed);
+                // First occurrence becomes the canonical link (no rename,
+                // nothing freed); only duplicates would be replaced.
+                let first = stats.dry_run_links.lock().unwrap().insert(hash.clone());
+                if !first {
+                    stats.files_linked.fetch_add(1, Ordering::Relaxed);
+                    stats.bytes_freed.fetch_add(meta.len(), Ordering::Relaxed);
+                }
                 return Ok(());
             }
             match fs::hard_link(&path, &link_path) {
@@ -250,12 +259,8 @@ async fn optimise_file(
     if lmeta.ino() == meta.ino() {
         return Ok(());
     }
-    if opts.dry_run {
-        stats.files_linked.fetch_add(1, Ordering::Relaxed);
-        stats.bytes_freed.fetch_add(meta.len(), Ordering::Relaxed);
-        return Ok(());
-    }
     // Size mismatch means a corrupt .links entry; don't merge.
+    // Checked before the dry-run accounting: a real run skips these too.
     if lmeta.len() != meta.len() {
         log::warn!(
             "link {} has size {} but file {} has size {}; skipping",
@@ -264,6 +269,11 @@ async fn optimise_file(
             path.display(),
             meta.len()
         );
+        return Ok(());
+    }
+    if opts.dry_run {
+        stats.files_linked.fetch_add(1, Ordering::Relaxed);
+        stats.bytes_freed.fetch_add(meta.len(), Ordering::Relaxed);
         return Ok(());
     }
 
@@ -788,11 +798,12 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn dry_run_counts_but_does_not_link() {
         let (stats, f1, f2, _tmp) = run_two_identical(0, true).await;
-        // .links is empty in dry-run, so both files count as linkable.
-        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 2);
+        // The first file would become the canonical .links entry and
+        // frees nothing; only the duplicate counts — matching a real run.
+        assert_eq!(stats.files_linked.load(Ordering::Relaxed), 1);
         assert_eq!(
             stats.bytes_freed.load(Ordering::Relaxed),
-            2 * CONTENT.len() as u64
+            CONTENT.len() as u64
         );
         assert_ne!(
             fs::metadata(&f1).unwrap().ino(),

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -525,6 +525,10 @@ pub fn cli_main() -> Result<()> {
     if errors > 0 {
         log::warn!("skipped {errors} file(s)/path(s) due to errors");
     }
+    let skipped = stats.files_skipped.load(Ordering::Relaxed);
+    if skipped > 0 {
+        log::info!("{skipped} file(s) skipped (writable or below --min-size)");
+    }
     let linked = stats.files_linked.load(Ordering::Relaxed);
     let freed = stats.bytes_freed.load(Ordering::Relaxed);
     if dry {

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -447,14 +447,17 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
                             return Ok(());
                         }
                     };
-                    // Walk done; release the slot before potentially
-                    // blocking on a full channel.
-                    drop(permit);
+                    // Hold the permit until the file list is drained:
+                    // releasing it earlier lets new walks pile up while
+                    // this one blocks on a full channel, accumulating
+                    // store-wide metadata in memory. No deadlock: the
+                    // consumer never takes walk permits.
                     for f in files {
                         if tx.send(f).await.is_err() {
                             break;
                         }
                     }
+                    drop(permit);
                     Ok(())
                 });
                 while let Some(res) = walks.try_join_next() {

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -311,12 +311,15 @@ fn libc_emlink() -> i32 {
 /// Hold gc.lock shared for the whole run so the GC (which takes it
 /// exclusive) cannot delete paths from under us.
 fn shared_gc_lock(state_dir: &Path) -> Result<Flock<fs::File>> {
+    use std::os::unix::fs::OpenOptionsExt;
     let lock_path = state_dir.join("gc.lock");
+    // 0600 like Nix's openLockFile.
     let f = fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(false)
+        .mode(0o600)
         .open(&lock_path)
         .with_context(|| format!("opening {}", lock_path.display()))?;
     match Flock::lock(f, FlockArg::LockSharedNonblock) {

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -497,12 +497,7 @@ pub async fn optimise_store(opts: Options) -> Result<Stats> {
 }
 
 pub fn cli_main() -> Result<()> {
-    let level = std::env::var("RUST_LOG")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(log::LevelFilter::Info);
-    log::set_boxed_logger(Box::new(StderrLogger(level))).unwrap();
-    log::set_max_level(level);
+    fast_nix_common::logging::init();
 
     let opts = parse_args()?;
     let dry = opts.dry_run;
@@ -585,19 +580,6 @@ fn parse_args() -> Result<Options> {
         bail!("unexpected arguments: {:?}", rest);
     }
     Ok(opts)
-}
-
-struct StderrLogger(log::LevelFilter);
-impl log::Log for StderrLogger {
-    fn enabled(&self, m: &log::Metadata) -> bool {
-        m.level() <= self.0
-    }
-    fn log(&self, r: &log::Record) {
-        if self.enabled(r.metadata()) {
-            eprintln!("[{:5}] {}", r.level(), r.args());
-        }
-    }
-    fn flush(&self) {}
 }
 
 #[cfg(test)]
@@ -736,16 +718,6 @@ mod tests {
         assert!(libc_enospc() > 1);
         assert!(libc_emlink() > 1);
         assert_ne!(libc_enospc(), libc_emlink());
-    }
-
-    #[test]
-    fn logger_respects_level_filter() {
-        use log::Log as _;
-        let logger = StderrLogger(log::LevelFilter::Info);
-        let info = log::Metadata::builder().level(log::Level::Info).build();
-        let debug = log::Metadata::builder().level(log::Level::Debug).build();
-        assert!(logger.enabled(&info));
-        assert!(!logger.enabled(&debug));
     }
 
     const CONTENT: &[u8] = b"hello world hello world hello world\n";

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -42,7 +42,7 @@ pkgs.testers.runNixOSTest {
     # Build a CA derivation directly in the system store.
     ca_drv_expr = (
         'derivation { '
-        'name = "ca-test"; system = "${pkgs.system}"; '
+        'name = "ca-test"; system = "${pkgs.stdenv.hostPlatform.system}"; '
         'builder = "/bin/sh"; args = ["-c" "echo hello > $out"]; '
         '__contentAddressed = true; outputHashMode = "recursive"; '
         'outputHashAlgo = "sha256"; }'
@@ -99,7 +99,7 @@ pkgs.testers.runNixOSTest {
         "cat > /tmp/ca-test2.nix <<'EOF'\n"
         "derivation {\n"
         '  name = "ca-test2";\n'
-        '  system = "${pkgs.system}";\n'
+        '  system = "${pkgs.stdenv.hostPlatform.system}";\n'
         '  builder = "/bin/sh";\n'
         '  args = ["-c" "echo hello2 > $out"];\n'
         "  __contentAddressed = true;\n"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   pkg-config,
-  nix,
   sqlite,
 }:
 let
@@ -28,10 +27,7 @@ rustPlatform.buildRustPackage {
     };
   };
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    nix
-    sqlite
-  ];
+  buildInputs = [ sqlite ];
   cargoBuildFlags = [
     "-p"
     "fast-nix-gc"

--- a/scripts/mkstore.py
+++ b/scripts/mkstore.py
@@ -5,7 +5,42 @@ import os
 import sqlite3
 import sys
 
-SCHEMA = open(os.path.join(os.path.dirname(__file__), "../tests/schema.sql")).read()
+# Nix's schema (nix/src/libstore/schema.sql), trimmed to the tables the
+# GC touches. Inlined because the repo ships no schema.sql file.
+SCHEMA = """
+create table if not exists ValidPaths (
+    id               integer primary key autoincrement not null,
+    path             text unique not null,
+    hash             text not null,
+    registrationTime integer not null,
+    deriver          text,
+    narSize          integer,
+    ultimate         integer,
+    sigs             text,
+    ca               text
+);
+
+create table if not exists Refs (
+    referrer  integer not null,
+    reference integer not null,
+    primary key (referrer, reference),
+    foreign key (referrer) references ValidPaths(id) on delete cascade,
+    foreign key (reference) references ValidPaths(id) on delete restrict
+);
+
+create index if not exists IndexReferrer on Refs(referrer);
+create index if not exists IndexReference on Refs(reference);
+
+create table if not exists DerivationOutputs (
+    drv  integer not null,
+    id   text not null,
+    path text not null,
+    primary key (drv, id),
+    foreign key (drv) references ValidPaths(id) on delete cascade
+);
+
+create index if not exists IndexDerivationOutputs on DerivationOutputs(path);
+"""
 
 
 def main() -> None:


### PR DESCRIPTION
## Wrong-deletion / data-loss fixes

- reject unknown CLI arguments (a typo'd `--dry-run` ran a real GC)
- normalize `--store-dir` and refuse to collect when it matches no DB path (a trailing slash made the whole store look dead)
- fail closed on I/O errors during root discovery and stale-auto-root cleanup
- never delete profile generations when the current one cannot be determined
- protect `.lock`/`.chroot`/`.check` files of active builds via temp-root hash parts
- close the protect-vs-invalidate ack race in the gc-socket
- create optimise temp links in the store root: a crash no longer corrupts the path's NAR contents
- stop scanning `$HOME` for profile generations

## Nix semantics alignment

- `--delete-older-than` keeps the generation that was active at the cutoff (rollback target)
- keep-derivations/keep-outputs edges now match Nix's GC exactly (`ValidPaths.deriver` only / output map only); the previous union pinned stale drvs and outputs forever
- temproots "d" deletion marker, reserved-space file removal, 0600 lock files, profile locking (PathLocks protocol), foreign_keys pragma
- optimise registers per-path temp roots (Nix's `addTempRoot` protocol) instead of holding `gc.lock` shared for the whole run, so GC and optimise can run concurrently
- the gc-socket is served immediately after taking the lock (also during dry runs), not only after the graph load

## Robustness

- gc-socket server survives transient accept/poll failures and caps line length
- optimise skips per-file errors instead of aborting; dry-run estimates match a real run
- non-UTF-8 store entries, FIFO `tmp-*` entries, deletion-error logging
- macOS `PROC_PIDFDVNODEPATHINFO` flavor fixed (fd roots were never found)
- time/size spec parsing no longer panics or wraps
- streaming `.links` cleanup, bounded optimise walk memory, busy timeout, read-only DB for dry runs

Plus dead-code removal and small CLI/reporting cleanups. Every behavioral fix has a regression test; workspace tests and clippy are clean.