### PR TITLE
CLI typo suggestions and quieter stale-root cleanup logs

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -132,3 +132,41 @@ mod tests {
 }
 pub mod nix_config;
 pub mod temp_roots;
+
+/// Closest CLI flag by edit distance, for "did you mean" hints.
+/// Returns None unless a candidate is within distance 3.
+pub fn closest_match<'a>(arg: &str, candidates: &[&'a str]) -> Option<&'a str> {
+    fn edit_distance(a: &str, b: &str) -> usize {
+        let (a, b): (Vec<char>, Vec<char>) = (a.chars().collect(), b.chars().collect());
+        let mut prev: Vec<usize> = (0..=b.len()).collect();
+        let mut cur = vec![0; b.len() + 1];
+        for i in 1..=a.len() {
+            cur[0] = i;
+            for j in 1..=b.len() {
+                let sub = prev[j - 1] + usize::from(a[i - 1] != b[j - 1]);
+                cur[j] = sub.min(prev[j] + 1).min(cur[j - 1] + 1);
+            }
+            std::mem::swap(&mut prev, &mut cur);
+        }
+        prev[b.len()]
+    }
+    candidates
+        .iter()
+        .map(|c| (edit_distance(arg, c), *c))
+        .filter(|&(d, _)| d <= 3)
+        .min()
+        .map(|(_, c)| c)
+}
+
+#[cfg(test)]
+mod closest_match_tests {
+    use super::closest_match;
+
+    #[test]
+    fn suggests_near_misses_only() {
+        let known = &["--dry-run", "--keep-recent", "--store-dir"];
+        assert_eq!(closest_match("--keep-resent", known), Some("--keep-recent"));
+        assert_eq!(closest_match("--dry-rnu", known), Some("--dry-run"));
+        assert_eq!(closest_match("--completely-different", known), None);
+    }
+}

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -85,8 +85,25 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
     };
     // A typo'd flag (e.g. --dry-rnu) must not silently run a destructive GC.
     let rest = pargs.finish();
-    if !rest.is_empty() {
-        bail!("unexpected arguments: {rest:?}");
+    if let Some(first) = rest.first() {
+        let arg = first.to_string_lossy();
+        const KNOWN: &[&str] = &[
+            "-d",
+            "--delete-old",
+            "--delete-older-than",
+            "--dry-run",
+            "--ensure-free",
+            "--keep-recent",
+            "--keep-outputs",
+            "--keep-derivations",
+            "--store-dir",
+            "--state-dir",
+            "--help",
+        ];
+        match fast_nix_common::closest_match(&arg, KNOWN) {
+            Some(s) => bail!("unexpected argument '{arg}'; did you mean '{s}'?"),
+            None => bail!("unexpected arguments: {rest:?} (see --help)"),
+        }
     }
     Ok(args)
 }
@@ -197,7 +214,12 @@ mod tests {
 
     #[test]
     fn parse_args_rejects_unknown_arguments() {
-        assert!(parse_args_from(args(&["--dry-rnu"])).is_err());
+        let err = parse_args_from(args(&["--dry-rnu"])).err().unwrap();
+        assert!(err.to_string().contains("--dry-run"), "{err}");
+        let err = parse_args_from(args(&["--keep-resent", "2d"]))
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("--keep-recent"), "{err}");
         assert!(parse_args_from(args(&["--dry-run", "extra"])).is_err());
         let parsed = parse_args_from(args(&["--dry-run"])).unwrap();
         assert!(parsed.dry_run);

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -115,7 +115,7 @@ fn find_roots_in_dir(
                     // Component match, not substring: "gcroots/automatic"
                     // must not qualify.
                     if dir.ends_with("gcroots/auto") {
-                        log::info!("removing stale link {}", path.display());
+                        log::debug!("removing stale link {}", path.display());
                         fs::remove_file(&path).ok();
                     }
                     continue;
@@ -674,7 +674,7 @@ pub fn find_temp_roots(state_dir: &Path) -> Result<HashSet<String>> {
         if let Ok(mut lock) =
             nix::fcntl::Flock::lock(f, nix::fcntl::FlockArg::LockExclusiveNonblock)
         {
-            log::info!("removing stale temporary roots file {}", path.display());
+            log::debug!("removing stale temporary roots file {}", path.display());
             fs::remove_file(&path).ok();
             // Nix protocol (gc.cc): write "d" after unlinking so a client
             // that re-acquires its fd sees the marker and recreates the

--- a/crates/optimise/src/optimise.rs
+++ b/crates/optimise/src/optimise.rs
@@ -581,8 +581,21 @@ fn parse_args() -> Result<Options> {
         opts.state_dir = v;
     }
     let rest = p.finish();
-    if !rest.is_empty() {
-        bail!("unexpected arguments: {:?}", rest);
+    if let Some(first) = rest.first() {
+        let arg = first.to_string_lossy();
+        const KNOWN: &[&str] = &[
+            "--dry-run",
+            "--min-size",
+            "-j",
+            "--jobs",
+            "--store-dir",
+            "--state-dir",
+            "--help",
+        ];
+        match fast_nix_common::closest_match(&arg, KNOWN) {
+            Some(s) => bail!("unexpected argument '{arg}'; did you mean '{s}'?"),
+            None => bail!("unexpected arguments: {rest:?} (see --help)"),
+        }
     }
     Ok(opts)
 }


### PR DESCRIPTION
Follow-ups to #29:

- Unknown arguments now suggest the closest known flag by edit distance
  (`--keep-resent` → `did you mean '--keep-recent'?`); pico-args has no
  built-in equivalent of clap's suggestions.
- Stale temproot files and dangling gcroots/auto links are removed as
  routine housekeeping; log that at debug level instead of info.