### PR TITLE
nix: include difftest in the proptest source fileset

### DIFF
--- a/nix/proptest.nix
+++ b/nix/proptest.nix
@@ -13,6 +13,7 @@ let
       ../Cargo.lock
       ../crates
       ../proptest
+      ../difftest
     ];
   };
 in


### PR DESCRIPTION
Fixes CI on main after b19cea1. Verified with `nix build .#checks.x86_64-linux.proptest`.