### PR TITLE
gc: vacuum the store db after mass deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ drv↔output mappings are read from `ValidPaths.deriver`,
 store is remounted read-write on NixOS where it's bind-mounted read-only.
 `tmp-*` build dirs are skipped if a builder still holds the lock.
 
+### Database vacuum
+
+SQLite never shrinks `db.sqlite` on its own, so after deletion the GC
+runs `VACUUM` when at least 25% of the file is free pages, still under
+the exclusive `gc.lock`. VACUUM is atomic: if it fails (e.g. out of
+disk for the temp copy) the database stays valid and the next GC
+retries. On a real-world 648 MB database that was 63% free pages,
+vacuuming shrank it to 216 MB and made the cold-cache graph load 4x
+faster (whole dry-run: 2.4x).
+
 ### Corrupted stores
 
 Disk and database can disagree after crashes or tampering. The GC

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -349,6 +349,27 @@ impl NixDb {
             }
         }
     }
+
+    /// VACUUM if enough of the file is free pages to be worth a full
+    /// rewrite: at least a quarter of the file and at least 64 pages
+    /// (256 KiB at the default page size). The caller must hold the
+    /// exclusive gc.lock so no Nix writer collides; concurrent readers
+    /// are fine in WAL mode. Returns whether a vacuum ran.
+    pub fn maybe_vacuum(&self) -> Result<bool> {
+        let freelist: i64 = self
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))?;
+        let pages: i64 = self.conn.query_row("PRAGMA page_count", [], |r| r.get(0))?;
+        if freelist < 64 || freelist * 4 < pages {
+            return Ok(false);
+        }
+        log::info!("vacuuming database ({freelist} of {pages} pages free)...");
+        self.conn.execute_batch("VACUUM")?;
+        // Best effort: a concurrent reader may block the WAL truncate;
+        // the next checkpoint picks it up.
+        let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)");
+        Ok(true)
+    }
 }
 
 /// Strip trailing slashes (but keep a bare "/").
@@ -533,6 +554,13 @@ mod tests {
                 rusqlite::params![referrer, reference],
             )
             .unwrap();
+    }
+
+    #[test]
+    fn maybe_vacuum_skips_small_freelist() {
+        let t = setup();
+        add_path(&t.db, &format!("{H1}-a"), 1, 1);
+        assert!(!t.db.maybe_vacuum().unwrap());
     }
 
     #[test]

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -513,6 +513,12 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     // Clean up unused hard links in .links
     let bytes_freed = bytes_freed + clean_links(&db.links_dir)?;
 
+    // Reclaim db space freed by the row deletions, still under the
+    // exclusive gc.lock. Best effort: a failed vacuum leaves the db valid.
+    if let Err(e) = db.maybe_vacuum() {
+        log::warn!("vacuuming database failed: {e:#}");
+    }
+
     Ok((bytes_freed, paths_deleted))
 }
 

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -1224,3 +1224,25 @@ fn gc_socket_root_mid_gc_keeps_path_and_deletes_rest() {
     assert!(!other.path.exists(), "other survived");
     assert!(!store.in_db(&other));
 }
+
+#[test]
+fn gc_vacuums_db_after_mass_deletion() {
+    let store = TestStore::new();
+    // Enough rows that deleting them leaves a freelist big enough to
+    // trip the auto-vacuum heuristic (>25% free pages, >=64 pages).
+    for i in 0..5000 {
+        store.add_path(&format!("dead-{i}-padpadpadpadpadpadpadpadpad"), 1);
+    }
+    let db_path = store.state_dir.join("db/db.sqlite");
+    let before = fs::metadata(&db_path).unwrap().len();
+
+    let out = store.run_gc_ok(&[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("vacuum"), "stderr: {stderr}");
+
+    let after = fs::metadata(&db_path).unwrap().len();
+    assert!(
+        after < before / 2,
+        "db not vacuumed: before={before} after={after}"
+    );
+}


### PR DESCRIPTION
Bulk-deleting ValidPaths/Refs rows leaves free pages that SQLite never
returns to the filesystem, so db.sqlite keeps growing. Vacuuming
externally requires stopping nix-daemon for exclusive write access.

GC already owns the safe window: it holds the exclusive gc.lock and
runs right after the row deletion, when the free pages exist. Vacuum
only when >=25% of the file and >=64 pages are free, so the full
rewrite happens only when it reclaims meaningful space.

VACUUM is atomic, so running out of disk for the temp copy just rolls
back and leaves the database valid; we log the failure and the next GC
retries — by then the deletion phase has usually freed enough space
anyway.

## Measurements

Real store db, 648 MB with 63% free pages:

| Metric | Before | After vacuum | Gain |
|---|---|---|---|
| File size | 648 MB | 216 MB | 3.0x smaller |
| Graph-load queries, cold cache | 0.94s | 0.23s | 4.1x |
| Graph-load queries, warm cache | 0.84s | 0.18s | 4.7x |
| `fast-nix-gc --dry-run`, cold cache | 6.27s | 2.62s | 2.4x |

Fewer pages to scan, and VACUUM rewrites rows in rowid order for
better locality.