### PR TITLE
gc: add --no-vacuum flag and noVacuum NixOS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ fast-nix-gc [OPTIONS]
       --dry-run                 Show what would be done
       --ensure-free SIZE        Free until SIZE is available (e.g. 50G)
       --keep-recent SPEC        Keep paths registered within SPEC (e.g. 1d)
+      --no-vacuum               Skip the database VACUUM after deletion
       --keep-outputs BOOL       Override the keep-outputs nix.conf setting
       --keep-derivations BOOL   Override the keep-derivations nix.conf setting
       --store-dir PATH          Nix store directory [default: /nix/store]
@@ -97,6 +98,7 @@ Replaces `nix.gc` and `nix.optimise`:
 | `deleteOlderThan` | `null` | Remove profile generations older than e.g. `"30d"` |
 | `ensureFree` | `null` | Stop once this much disk is free, e.g. `"50G"` |
 | `keepRecent` | `null` | Pin paths registered within e.g. `"1d"` |
+| `noVacuum` | `false` | Skip the post-GC database VACUUM (see below) |
 | `package` | this flake's package | Override the binary |
 | `extraArgs` | `[ ]` | Extra CLI arguments |
 
@@ -115,6 +117,19 @@ Replaces `nix.gc` and `nix.optimise`:
 | `extraArgs` | `[ ]` | Extra CLI arguments |
 
 Without flakes, import `nix/module.nix` directly.
+
+### When to use `--no-vacuum` / `noVacuum`
+
+After deleting dead paths, fast-nix-gc runs `VACUUM` when at least a
+quarter of the database is free pages. In WAL mode this rewrites the
+entire database through the write-ahead log, and SQLite cannot truncate
+the resulting database-sized `db.sqlite-wal` while any connection holds
+a read snapshot. This is the reason Nix disabled GC vacuuming in commit
+[`8299aaf`](https://github.com/NixOS/nix/commit/8299aaf07988a3ca7ecda3526b7e25a885550db5).
+
+On builders that are never idle, enable `--no-vacuum`: the free pages
+stay in `db.sqlite` and are reused for new registrations, and a later GC
+on a quiet system reclaims the space.
 
 ## Building
 

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -123,6 +123,10 @@ pub struct GcOptions {
     pub max_freed: Option<u64>,
     /// Keep paths registered at or after this Unix timestamp.
     pub keep_recent_after: Option<i64>,
+    /// Skip the post-GC VACUUM. For busy builders, where concurrent
+    /// readers keep the VACUUM's database-sized WAL from being
+    /// truncated (the problem behind Nix commit 8299aaf).
+    pub no_vacuum: bool,
 }
 
 /// Main GC: find roots, compute alive closure, delete dead paths.
@@ -512,6 +516,14 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
 
     // Clean up unused hard links in .links
     let bytes_freed = bytes_freed + clean_links(&db.links_dir)?;
+
+    // Reclaim db space freed by the row deletions, still under the
+    // exclusive gc.lock. Best effort: a failed vacuum leaves the db valid.
+    if !opts.no_vacuum
+        && let Err(e) = db.maybe_vacuum()
+    {
+        log::warn!("vacuuming database failed: {e:#}");
+    }
 
     // Reclaim db space freed by the row deletions, still under the
     // exclusive gc.lock. Best effort: a failed vacuum leaves the db valid.

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -10,6 +10,7 @@ struct Args {
     dry_run: bool,
     ensure_free: Option<u64>,
     keep_recent: Option<String>,
+    no_vacuum: bool,
     keep_outputs: Option<bool>,
     keep_derivations: Option<bool>,
     store_dir: PathBuf,
@@ -57,6 +58,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         println!("      --dry-run                 Show what would be done");
         println!("      --ensure-free SIZE        Free until SIZE is available (e.g. 50G)");
         println!("      --keep-recent SPEC        Keep paths registered within SPEC (e.g. 7d)");
+        println!("      --no-vacuum               Skip the database VACUUM after deletion");
         println!("      --keep-outputs BOOL       Override the keep-outputs nix.conf setting");
         println!("      --keep-derivations BOOL   Override the keep-derivations nix.conf setting");
         println!("      --store-dir PATH          Nix store directory [default: /nix/store]");
@@ -74,6 +76,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         dry_run: pargs.contains("--dry-run"),
         ensure_free: pargs.opt_value_from_fn("--ensure-free", parse_size)?,
         keep_recent: pargs.opt_value_from_str("--keep-recent")?,
+        no_vacuum: pargs.contains("--no-vacuum"),
         keep_outputs: pargs.opt_value_from_str("--keep-outputs")?,
         keep_derivations: pargs.opt_value_from_str("--keep-derivations")?,
         store_dir: pargs
@@ -94,6 +97,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
             "--dry-run",
             "--ensure-free",
             "--keep-recent",
+            "--no-vacuum",
             "--keep-outputs",
             "--keep-derivations",
             "--store-dir",
@@ -186,6 +190,7 @@ fn main() -> Result<()> {
         dry_run: args.dry_run,
         max_freed,
         keep_recent_after,
+        no_vacuum: args.no_vacuum,
     };
     let (bytes_freed, paths_deleted) = gc::collect_garbage(&store, &opts)?;
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -73,6 +73,16 @@ in
       '';
     };
 
+    noVacuum = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Skip the SQLite VACUUM after garbage collection. Enable on busy
+        builders, where concurrent nix-daemon readers prevent cleanup of
+        the database-sized WAL that VACUUM produces; see the README.
+      '';
+    };
+
     extraArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -174,6 +184,7 @@ in
               "--keep-recent"
               cfg.keepRecent
             ]
+            ++ lib.optional cfg.noVacuum "--no-vacuum"
             ++ cfg.extraArgs
           );
         };


### PR DESCRIPTION

The post-GC VACUUM rewrites the whole database through the WAL. On a
busy builder, where nix-daemon clients continuously hold read
snapshots, SQLite cannot truncate that WAL, so a file roughly the size
of the database lingers in /nix/var/nix/db. This is the same problem
that made Nix disable GC vacuuming in commit [8299aaf](https://github.com/NixOS/nix/commit/8299aaf).

Let operators opt out on such machines; the freed pages remain inside
db.sqlite and are reused, and a later GC on a quiet system reclaims the
space.
