### PR TITLE
gc: resolve indirect roots without following the symlink

### DIFF
--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -93,60 +93,7 @@ fn find_roots_in_dir(
                     roots.insert(idx);
                 }
             } else {
-                // Indirect root: symlink -> symlink -> store.
-                // Nix's findRoots resolves at most one extra hop. Resolve it
-                // with lstat + readlink, never a following stat(): under
-                // fs.protected_symlinks, following a user-owned link in a
-                // sticky directory like /tmp fails with EACCES, even for root.
-                let abs_target = if target.is_absolute() {
-                    target.clone()
-                } else {
-                    dir.join(&target)
-                };
-                let target_meta = match fs::symlink_metadata(&abs_target) {
-                    Ok(m) => m,
-                    // First hop gone: the indirect root was removed.
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        remove_stale_auto_link(dir, &path);
-                        continue;
-                    }
-                    // EACCES/EIO say nothing about the target's existence:
-                    // dropping the root could let the GC delete a live path.
-                    Err(e) => {
-                        return Err(e).with_context(|| format!("stat {}", abs_target.display()));
-                    }
-                };
-                if !target_meta.file_type().is_symlink() {
-                    // Plain file or directory: not an indirect store root.
-                    continue;
-                }
-                let target2 = match fs::read_link(&abs_target) {
-                    Ok(t) => t,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-                    Err(e) => {
-                        return Err(e)
-                            .with_context(|| format!("readlink {}", abs_target.display()));
-                    }
-                };
-                if let Some(sp) = extract_store_path(store_prefix, &target2.to_string_lossy())
-                    && let Some(idx) = idx.idx_of(&sp)
-                {
-                    roots.insert(idx);
-                    continue;
-                }
-                // No live root behind the link. Clean dangling auto links,
-                // but only when the second hop provably does not exist:
-                // EACCES/EIO prove nothing.
-                let abs_target2 = if target2.is_absolute() {
-                    target2
-                } else {
-                    abs_target.parent().unwrap_or(Path::new("/")).join(target2)
-                };
-                if fs::symlink_metadata(&abs_target2)
-                    .is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound)
-                {
-                    remove_stale_auto_link(dir, &path);
-                }
+                resolve_indirect_root(dir, &path, &target, store_prefix, idx, roots)?;
             }
         } else if meta.file_type().is_dir() {
             find_roots_in_dir(&path, store_prefix, idx, roots)?;
@@ -158,6 +105,66 @@ fn find_roots_in_dir(
                 roots.insert(idx);
             }
         }
+    }
+    Ok(())
+}
+
+/// Indirect root: symlink -> symlink -> store. Nix's findRoots resolves at
+/// most one extra hop. Resolve it with lstat + readlink, never a following
+/// stat(): under fs.protected_symlinks, following a user-owned link in a
+/// sticky directory like /tmp fails with EACCES, even for root.
+fn resolve_indirect_root(
+    dir: &Path,
+    link: &Path,
+    target: &Path,
+    store_prefix: &str,
+    idx: &BasenameIndex,
+    roots: &mut HashSet<u32>,
+) -> Result<()> {
+    let abs_target = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        dir.join(target)
+    };
+    let target_meta = match fs::symlink_metadata(&abs_target) {
+        Ok(m) => m,
+        // First hop gone: the indirect root was removed.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            remove_stale_auto_link(dir, link);
+            return Ok(());
+        }
+        // EACCES/EIO say nothing about the target's existence:
+        // dropping the root could let the GC delete a live path.
+        Err(e) => {
+            return Err(e).with_context(|| format!("stat {}", abs_target.display()));
+        }
+    };
+    if !target_meta.file_type().is_symlink() {
+        // Plain file or directory: not an indirect store root.
+        return Ok(());
+    }
+    let target2 = match fs::read_link(&abs_target) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(e).with_context(|| format!("readlink {}", abs_target.display()));
+        }
+    };
+    if let Some(sp) = extract_store_path(store_prefix, &target2.to_string_lossy())
+        && let Some(idx) = idx.idx_of(&sp)
+    {
+        roots.insert(idx);
+        return Ok(());
+    }
+    // No live root behind the link. Clean dangling auto links, but only when
+    // the second hop provably does not exist: EACCES/EIO prove nothing.
+    let abs_target2 = if target2.is_absolute() {
+        target2
+    } else {
+        abs_target.parent().unwrap_or(Path::new("/")).join(target2)
+    };
+    if fs::symlink_metadata(&abs_target2).is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound) {
+        remove_stale_auto_link(dir, link);
     }
     Ok(())
 }

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -94,45 +94,58 @@ fn find_roots_in_dir(
                 }
             } else {
                 // Indirect root: symlink -> symlink -> store.
-                // Nix's findRoots resolves at most one extra hop. Use
-                // symlink_metadata to avoid recursive follow / symlink loops.
+                // Nix's findRoots resolves at most one extra hop. Resolve it
+                // with lstat + readlink, never a following stat(): under
+                // fs.protected_symlinks, following a user-owned link in a
+                // sticky directory like /tmp fails with EACCES, even for root.
                 let abs_target = if target.is_absolute() {
                     target.clone()
                 } else {
                     dir.join(&target)
                 };
-                // metadata() (stat, follows) returns ENOENT for dangling
-                // links and ELOOP for cycles — both are "target gone".
-                // Any other error (EACCES, EIO) says nothing about the
-                // target's existence: removing the root then would let the
-                // GC delete a live path.
-                if let Err(e) = fs::metadata(&abs_target) {
-                    let target_gone = e.kind() == std::io::ErrorKind::NotFound
-                        || e.raw_os_error() == Some(nix::errno::Errno::ELOOP as i32);
-                    if !target_gone {
+                let target_meta = match fs::symlink_metadata(&abs_target) {
+                    Ok(m) => m,
+                    // First hop gone: the indirect root was removed.
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        remove_stale_auto_link(dir, &path);
+                        continue;
+                    }
+                    // EACCES/EIO say nothing about the target's existence:
+                    // dropping the root could let the GC delete a live path.
+                    Err(e) => {
                         return Err(e).with_context(|| format!("stat {}", abs_target.display()));
                     }
-                    // Component match, not substring: "gcroots/automatic"
-                    // must not qualify.
-                    if dir.ends_with("gcroots/auto") {
-                        log::debug!("removing stale link {}", path.display());
-                        fs::remove_file(&path).ok();
-                    }
+                };
+                if !target_meta.file_type().is_symlink() {
+                    // Plain file or directory: not an indirect store root.
                     continue;
                 }
-                if abs_target
-                    .symlink_metadata()
-                    .map(|m| m.file_type().is_symlink())
-                    .unwrap_or(false)
-                    && let Ok(target2) = fs::read_link(&abs_target)
-                {
-                    let t2_str = target2.to_string_lossy();
-                    if is_in_store(store_prefix, &t2_str)
-                        && let Some(sp) = extract_store_path(store_prefix, &t2_str)
-                        && let Some(idx) = idx.idx_of(&sp)
-                    {
-                        roots.insert(idx);
+                let target2 = match fs::read_link(&abs_target) {
+                    Ok(t) => t,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(e) => {
+                        return Err(e)
+                            .with_context(|| format!("readlink {}", abs_target.display()));
                     }
+                };
+                if let Some(sp) = extract_store_path(store_prefix, &target2.to_string_lossy())
+                    && let Some(idx) = idx.idx_of(&sp)
+                {
+                    roots.insert(idx);
+                    continue;
+                }
+                // No live root behind the link. Clean dangling auto links,
+                // but only when the second hop provably does not exist:
+                // EACCES/EIO prove nothing.
+                let abs_target2 = if target2.is_absolute() {
+                    target2
+                } else {
+                    abs_target.parent().unwrap_or(Path::new("/")).join(target2)
+                };
+                if fs::symlink_metadata(&abs_target2)
+                    .is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound)
+                {
+                    remove_stale_auto_link(dir, &path);
                 }
             }
         } else if meta.file_type().is_dir() {
@@ -147,6 +160,15 @@ fn find_roots_in_dir(
         }
     }
     Ok(())
+}
+
+/// Remove a dangling link in gcroots/auto. Component match, not substring:
+/// "gcroots/automatic" must not qualify.
+fn remove_stale_auto_link(dir: &Path, link: &Path) {
+    if dir.ends_with("gcroots/auto") {
+        log::debug!("removing stale link {}", link.display());
+        fs::remove_file(link).ok();
+    }
 }
 
 /// Extract the top-level store path from a potentially deeper path.

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -1008,6 +1008,69 @@ fn gc_keeps_auto_root_with_unreadable_target() {
 }
 
 #[test]
+fn gc_keeps_indirect_auto_root() {
+    // auto link -> user symlink -> store path. This covers ordinary
+    // indirect-root retention; the next test covers an unfollowable second hop,
+    // which is the property protected_symlinks exposes in practice.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    let user_link = store.dir.path().join("result");
+    std::os::unix::fs::symlink(&lib.path, &user_link).unwrap();
+    std::os::unix::fs::symlink(&user_link, auto.join("x0")).unwrap();
+
+    store.run_gc_ok(&[]);
+
+    assert!(
+        lib.path.exists() && store.in_db(&lib),
+        "indirect root deleted"
+    );
+    assert!(
+        auto.join("x0").symlink_metadata().is_ok(),
+        "live auto root removed"
+    );
+}
+
+#[test]
+fn gc_scans_roots_despite_unfollowable_indirect_target() {
+    use std::os::unix::fs::PermissionsExt;
+    if nix::unistd::geteuid().is_root() {
+        return; // root bypasses permission checks
+    }
+    // A readable link whose target only fails to resolve *through* it
+    // (here: second hop in a mode-000 dir, standing in for
+    // fs.protected_symlinks, which a test cannot flip) is provably not a
+    // store root — the scan must carry on, not abort.
+    let store = TestStore::new();
+    let lib = store.add_path("lib", 100);
+    store.add_root("keep", &lib);
+    let auto = store.state_dir.join("gcroots/auto");
+    fs::create_dir_all(&auto).unwrap();
+    let private = store.dir.path().join("private");
+    fs::create_dir_all(&private).unwrap();
+    fs::write(private.join("notes"), "").unwrap();
+    let user_link = store.dir.path().join("result");
+    std::os::unix::fs::symlink(private.join("notes"), &user_link).unwrap();
+    std::os::unix::fs::symlink(&user_link, auto.join("x0")).unwrap();
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let out = store.run_gc(&[]);
+
+    fs::set_permissions(&private, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        out.status.success(),
+        "scan aborted on unfollowable non-store target: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(lib.path.exists() && store.in_db(&lib), "live path deleted");
+    assert!(
+        auto.join("x0").symlink_metadata().is_ok(),
+        "auto root with unprovable target removed"
+    );
+}
+
+#[test]
 fn gc_removes_dangling_auto_root() {
     let store = TestStore::new();
     let auto = store.state_dir.join("gcroots/auto");


### PR DESCRIPTION
## Problem

With `fs.protected_symlinks=1` (the default on NixOS and most distros), a following `stat()` through a user-owned symlink in a sticky world-writable directory is denied with EACCES **even for root**. `/tmp` is exactly where indirect roots from `nix build -o /tmp/...` land, so root scanning aborts the whole GC since 4d935c9 (gc: fail closed when root discovery hits I/O errors):

```
Error: scanning roots in /nix/var/nix/gcroots
Caused by:
    0: stat /tmp/khanelinix-davmail-properties
    1: Permission denied (os error 13)
```

Net effect: any user can (accidentally) wedge the system GC by leaving a build result link in `/tmp`. Hit this in production via the NixOS module's `fast-nix-gc.service`. Stock `nix-collect-garbage` is not affected — it resolves the hop with readlink rather than stat'ing through the link.

## Fix

Resolve the one extra hop manually with `lstat` + `readlink` — neither is affected by `protected_symlinks`, and they yield the store target directly, so the following `stat()` is unnecessary.

Fail-closed semantics preserved:
- `lstat` errors other than ENOENT on the first hop still abort the scan (`gc_keeps_auto_root_with_unreadable_target` stays green)
- stale auto links are removed only when a hop provably does not exist (ENOENT), never on EACCES/EIO

Two intentional behavior changes, both toward keeping more:
- symlink loops in `gcroots/auto` are no longer removed (old ELOOP case); they simply contribute no root
- an indirect root whose store target is valid in the DB but missing on disk now keeps its root and auto link instead of being dropped; the unknown-on-disk handling owns that inconsistency

## Testing

- two new integration tests: indirect root resolved without following the link; scan survives an unfollowable (EACCES) non-store indirect target that previously aborted it (the sysctl itself can't be flipped in a test, so a mode-000 directory stands in for the deny-on-follow property)
- `cargo test -p fast-nix-gc`: 44 passed; clippy and fmt clean
- live verification on the affected host, user-owned `/tmp` indirect root present: release 161fc69 reproduces the abort, patched binary completes `--dry-run` with the root protected

Fixes #39
@Mic92 just noticed this should also solve issue reported yesterday that I just ran into. 