### PR TITLE
flake: include packages and devShells in checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,12 @@
   };
 
   outputs =
-    { nixpkgs, treefmt-nix, ... }:
+    {
+      self,
+      nixpkgs,
+      treefmt-nix,
+      ...
+    }:
     let
       forAllSystems = nixpkgs.lib.genAttrs [
         "x86_64-linux"
@@ -43,10 +48,10 @@
         in
         {
           proptest = pkgs.callPackage ./nix/proptest.nix { };
-        }
-        // {
           treefmt = (import ./nix/treefmt.nix { inherit pkgs treefmt-nix; }).config.build.check ./.;
         }
+        // nixpkgs.lib.mapAttrs' (n: nixpkgs.lib.nameValuePair "package-${n}") self.packages.${system}
+        // nixpkgs.lib.mapAttrs' (n: nixpkgs.lib.nameValuePair "devshell-${n}") self.devShells.${system}
         // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           nixos-test = import ./nix/nixos-test.nix { inherit pkgs; };
         }


### PR DESCRIPTION
Buildbot only evaluates the `checks` output, so the cargo integration tests in the package's checkPhase never ran on darwin and #40 went unnoticed. Map all `packages` and `devShells` into `checks` so CI builds and tests them on every system.