### PR TITLE
Make GC more robust on all-most full system

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ fast-nix-gc [OPTIONS]
 ## fast-nix-optimise
 
 Hardlink-based store dedup, on-disk compatible with `nix-store --optimise`:
-same `.links/` layout, same NAR-SHA-256 filenames, the two can be mixed
-freely. Hashing and linking run as concurrent tokio tasks; a steady-state
-store where most files are already deduped is skipped via `d_ino` from
-readdir without rehashing. ~2x faster than upstream on a warm store.
+It uses the same `.links/` layout and the same NAR-SHA-256 filenames
+Hashing and linking run as concurrent tokio tasks.
+An already deduped store is skipped via `d_ino` from readdir without rehashing.
+We measured ~2x faster than upstream on a warm store.
 
 ```
 fast-nix-optimise [OPTIONS]
@@ -50,9 +50,8 @@ fast-nix-optimise [OPTIONS]
 
 Both tools take a shared `gc.lock` so they don't race each other or Nix.
 While fast-nix-gc deletes, it serves the GC roots socket
-(`state/gc-socket/socket`, same protocol as `nix-store --gc`), so concurrent
-`nix build`s register temp roots without blocking on the lock.
-`--store-dir`/`--state-dir` let you point at a separate store for testing.
+(`state/gc-socket/socket` same as `nix-store --gc`).
+A concurrent `nix build`s register temp roots without blocking on the lock.
 
 ## NixOS module
 
@@ -124,14 +123,14 @@ Without flakes, import `nix/module.nix` directly.
 
 After deleting dead paths, fast-nix-gc runs `VACUUM` when at least a
 quarter of the database is free pages. In WAL mode this rewrites the
-entire database through the write-ahead log, and SQLite cannot truncate
+entire database through the write-ahead log. SQLite cannot truncate
 the resulting database-sized `db.sqlite-wal` while any connection holds
 a read snapshot. This is the reason Nix disabled GC vacuuming in commit
 [`8299aaf`](https://github.com/NixOS/nix/commit/8299aaf07988a3ca7ecda3526b7e25a885550db5).
 
-On builders that are never idle, enable `--no-vacuum`: the free pages
-stay in `db.sqlite` and are reused for new registrations, and a later GC
-on a quiet system reclaims the space.
+On builders that are never idle, enable `--no-vacuum`. The free pages
+stay in `db.sqlite` and are reused for new registrations.
+A later GC on a quiet system reclaims the space.
 
 ### Tuning `--chunk-size` / `chunkSize`
 
@@ -188,14 +187,16 @@ Two fuzzers back the behavioral claims below:
 Roots are gathered from `gcroots/`, `profiles/`, `temproots/`, and running
 processes (`/proc` on Linux; `libproc` syscalls on macOS instead of
 shelling out to `lsof`). Stale temp-root files and dangling auto-roots are
-removed. `keep-derivations` and `keep-outputs` are honored with the same
+removed. `tmp-*` build dirs are skipped if a builder still holds the lock.
+
+`keep-derivations` and `keep-outputs` are honored with the same
 edge semantics as `nix-store --gc`: an alive output keeps its derivation
 (`keep-derivations`), an alive derivation keeps its outputs
 (`keep-outputs`). This includes content-addressed / dynamic derivations:
 drv↔output mappings are read from `ValidPaths.deriver`,
-`DerivationOutputs`, and the `BuildTraceV3` table (Nix ≥2.35). The
-store is remounted read-write on NixOS where it's bind-mounted read-only.
-`tmp-*` build dirs are skipped if a builder still holds the lock.
+`DerivationOutputs`, and the `BuildTraceV3` table (Nix ≥2.35).
+
+The store is remounted read-write on NixOS where it's bind-mounted read-only.
 
 ### Database vacuum
 
@@ -259,5 +260,5 @@ controlled measurement.
 The speedup grows with store size: stock `nix-gc` pays a large fixed cost
 walking the whole live closure even when there's almost nothing to delete
 (near-idle runs still took minutes on the bigger machines), while
-`fast-nix-gc` stays in the single-digit-seconds range. On a tiny store
-the overhead is negligible either way and the two are roughly comparable.
+`fast-nix-gc` stays in the single-digit-seconds range.
+On a tiny store the overhead is negligible either way and the two are roughly comparable.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ fast-nix-gc [OPTIONS]
       --ensure-free SIZE        Free until SIZE is available (e.g. 50G)
       --keep-recent SPEC        Keep paths registered within SPEC (e.g. 1d)
       --no-vacuum               Skip the database VACUUM after deletion
+      --chunk-size N            Dead paths per delete transaction [default: 65536]
       --keep-outputs BOOL       Override the keep-outputs nix.conf setting
       --keep-derivations BOOL   Override the keep-derivations nix.conf setting
       --store-dir PATH          Nix store directory [default: /nix/store]
@@ -99,6 +100,7 @@ Replaces `nix.gc` and `nix.optimise`:
 | `ensureFree` | `null` | Stop once this much disk is free, e.g. `"50G"` |
 | `keepRecent` | `null` | Pin paths registered within e.g. `"1d"` |
 | `noVacuum` | `false` | Skip the post-GC database VACUUM (see below) |
+| `chunkSize` | `null` | Dead paths per delete transaction (default 65536) |
 | `package` | this flake's package | Override the binary |
 | `extraArgs` | `[ ]` | Extra CLI arguments |
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,35 @@ On builders that are never idle, enable `--no-vacuum`: the free pages
 stay in `db.sqlite` and are reused for new registrations, and a later GC
 on a quiet system reclaims the space.
 
+### Tuning `--chunk-size` / `chunkSize`
+
+Dead paths are invalidated in batches, one SQLite transaction per batch,
+with the write-ahead log truncated after each. The batch size trades disk
+headroom against checkpoint overhead:
+
+- **Smaller** keeps each transaction's `db.sqlite-wal` small. A single
+  transaction over the whole dead set grows the WAL until commit.
+  On a full disk that aborts with `SQLITE_FULL` and frees nothing.
+  Chunking bounds the WAL and reclaims space incrementally.
+- **Larger** means fewer transactions and fewer checkpoint `fsync`s, so
+  deletion runs faster, at the cost of a larger transient WAL.
+
+As a rule of thumb, deleting a path dirties scattered B-tree pages across
+the references table and its indexes, costing very roughly 10 KiB of WAL
+per dead path on a large, cold store, so a batch's WAL is about
+`chunk-size × 10 KiB`. The default of 65536 keeps it near 640 MiB, safe on
+all but a nearly full disk. With tens of GiB free, `--chunk-size 262144`
+(~2.5 GiB WAL) cuts the checkpoint count ~4x.
+Only higher when you have enough free disk space,
+since the WAL grows linearly with the batch size.
+
+The truncation after each batch can only reclaim WAL frames older than the
+oldest live read snapshot. A long-running reader i.e. `nix-daemon` pins those frames,
+so the WAL keeps growing across batches regardless of `--chunk-size`, potentially until the disk fills.
+For a large GC on a tight disk stop `nix-daemon` (and any other store reader) first, or
+keep the chunk size small enough that even an unreclaimed WAL fits the free
+space.
+
 ## Building
 
     nix build

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -365,6 +365,11 @@ impl NixDb {
         match result {
             Ok(()) => {
                 self.conn.execute_batch("COMMIT")?;
+                // Truncate the WAL back to the main db so its disk use
+                // doesn't accumulate across chunks. On a full disk an
+                // unbounded WAL would abort a later chunk. Best effort:
+                // a blocked checkpoint just leaves the WAL for the next.
+                let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)");
                 Ok(())
             }
             Err(e) => {

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -119,6 +119,7 @@ impl NixDb {
         let mut ids: Vec<i64> = Vec::new();
         let mut nar_sizes: Vec<u64> = Vec::new();
         let mut registration_times: Vec<i64> = Vec::new();
+        let t_nodes = std::time::Instant::now();
         {
             let mut stmt = self
                 .conn
@@ -140,12 +141,21 @@ impl NixDb {
             }
         }
 
+        log::debug!(
+            "loaded {} nodes in {:.1}s",
+            paths.len(),
+            t_nodes.elapsed().as_secs_f64()
+        );
+
         // CSR adjacency: flat target array + per-node offsets.
         let n = paths.len();
         let mut edges: Vec<(u32, u32)> = Vec::new();
+        let t_edges = std::time::Instant::now();
 
         let mut add_edges =
             |conn: &Connection, sql: &str, params: &[&dyn rusqlite::ToSql]| -> Result<()> {
+                let start = std::time::Instant::now();
+                let before = edges.len();
                 let mut stmt = conn.prepare(sql)?;
                 let mut rows = stmt.query(params)?;
                 while let Some(row) = rows.next()? {
@@ -157,6 +167,11 @@ impl NixDb {
                         edges.push((from, to));
                     }
                 }
+                log::debug!(
+                    "edge query took {:.1}s ({} edges): {sql}",
+                    start.elapsed().as_secs_f64(),
+                    edges.len() - before,
+                );
                 Ok(())
             };
 
@@ -229,6 +244,12 @@ impl NixDb {
                 )?;
             }
         }
+
+        log::debug!(
+            "loaded {} edges in {:.1}s",
+            edges.len(),
+            t_edges.elapsed().as_secs_f64()
+        );
 
         // CSR offsets are u32; refuse to build a graph the index type
         // cannot address instead of silently wrapping.
@@ -367,10 +388,12 @@ impl NixDb {
             return Ok(false);
         }
         log::info!("vacuuming database ({freelist} of {pages} pages free)...");
+        let start = std::time::Instant::now();
         self.conn.execute_batch("VACUUM")?;
         // Best effort: a concurrent reader may block the WAL truncate;
         // the next checkpoint picks it up.
         let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)");
+        log::info!("vacuum done in {:.1}s", start.elapsed().as_secs_f64());
         Ok(true)
     }
 }

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -116,6 +116,7 @@ impl NixDb {
         let mut id_to_idx = vec![MISSING; (max_id as usize) + 1];
 
         let mut paths: Vec<String> = Vec::new();
+        let mut ids: Vec<i64> = Vec::new();
         let mut nar_sizes: Vec<u64> = Vec::new();
         let mut registration_times: Vec<i64> = Vec::new();
         {
@@ -133,6 +134,7 @@ impl NixDb {
                     id_to_idx[id as usize] = idx;
                 }
                 paths.push(path);
+                ids.push(id);
                 nar_sizes.push(nar.unwrap_or(0).max(0) as u64);
                 registration_times.push(reg_time);
             }
@@ -252,6 +254,7 @@ impl NixDb {
 
         Ok(StoreGraph {
             paths,
+            ids,
             nar_sizes,
             registration_times,
             ref_offsets,
@@ -292,23 +295,23 @@ impl NixDb {
         Ok(n > 0)
     }
 
-    /// Remove paths from the DB in a single transaction.
-    pub fn invalidate_paths<'a>(&self, paths: impl Iterator<Item = &'a str>) -> Result<()> {
+    /// Remove paths by their ValidPaths.id in a single transaction. The
+    /// caller holds the ids from `load_graph`, so deletion is a rowid
+    /// insert into DeadPaths rather than a per-path index lookup.
+    pub fn invalidate_ids(&self, ids: impl Iterator<Item = i64>) -> Result<()> {
         self.conn.execute_batch("BEGIN")?;
         let result = (|| -> Result<()> {
-            // Collect the ids of paths to delete into a temp table so
-            // we can batch-delete their Refs in two statements instead
-            // of one subquery per path.
+            // Collect the dead ids in a temp table so their Refs can be
+            // batch-deleted in two statements instead of one subquery
+            // per path.
             self.conn.execute_batch(
                 "CREATE TEMP TABLE IF NOT EXISTS DeadPaths (id INTEGER PRIMARY KEY)",
             )?;
             self.conn.execute_batch("DELETE FROM DeadPaths")?;
             {
-                let mut ins = self
-                    .conn
-                    .prepare("INSERT INTO DeadPaths SELECT id FROM ValidPaths WHERE path = ?")?;
-                for p in paths {
-                    ins.execute([p])?;
+                let mut ins = self.conn.prepare("INSERT INTO DeadPaths VALUES (?)")?;
+                for id in ids {
+                    ins.execute([id])?;
                 }
             }
             // Delete reference edges involving dead paths first.
@@ -387,6 +390,9 @@ fn normalize_dir(dir: &Path) -> PathBuf {
 pub struct StoreGraph {
     /// node idx -> store path string
     pub paths: Vec<String>,
+    /// node idx -> ValidPaths.id (DB primary key). Lets invalidation
+    /// delete by rowid instead of re-resolving each path string.
+    pub ids: Vec<i64>,
     /// node idx -> narSize (bytes)
     pub nar_sizes: Vec<u64>,
     /// node idx -> registrationTime (Unix epoch seconds)
@@ -436,6 +442,7 @@ impl StoreGraph {
     pub fn empty(store_prefix: String) -> StoreGraph {
         StoreGraph {
             paths: Vec::new(),
+            ids: Vec::new(),
             nar_sizes: Vec::new(),
             registration_times: Vec::new(),
             ref_offsets: vec![0],
@@ -745,7 +752,7 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_paths_handles_ref_cycles() {
+    fn invalidate_ids_handles_ref_cycles() {
         let t = setup();
         let a = add_path(&t.db, &format!("{H1}-a"), 1, 1);
         let b = add_path(&t.db, &format!("{H2}-b"), 1, 1);
@@ -755,9 +762,7 @@ mod tests {
         add_ref(&t.db, a, b);
         add_ref(&t.db, b, a);
 
-        let dead = [full(&format!("{H1}-a")), full(&format!("{H2}-b"))];
-        t.db.invalidate_paths(dead.iter().map(|s| s.as_str()))
-            .unwrap();
+        t.db.invalidate_ids([a, b].into_iter()).unwrap();
 
         let remaining: Vec<String> =
             t.db.valid_store_paths()
@@ -774,7 +779,7 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_paths_cascades_derivation_outputs() {
+    fn invalidate_ids_cascades_derivation_outputs() {
         let t = setup();
         let drv = add_path(&t.db, &format!("{H1}-pkg.drv"), 1, 1);
         let out = add_path(&t.db, &format!("{H2}-pkg"), 1, 1);
@@ -786,9 +791,7 @@ mod tests {
             .unwrap();
         let _ = out;
 
-        let dead = [full(&format!("{H1}-pkg.drv"))];
-        t.db.invalidate_paths(dead.iter().map(|s| s.as_str()))
-            .unwrap();
+        t.db.invalidate_ids([drv].into_iter()).unwrap();
 
         let n: i64 =
             t.db.conn
@@ -798,7 +801,7 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_paths_clears_realisations_with_restrict_fk() {
+    fn invalidate_ids_clears_realisations_with_restrict_fk() {
         // Nix ≤2.34 CA schema: RealisationsRefs.realisationReference is ON
         // DELETE RESTRICT. Bulk-deleting two dead paths whose realisations
         // reference each other must not trip the constraint.
@@ -830,9 +833,7 @@ mod tests {
             ))
             .unwrap();
 
-        let dead = [full(&format!("{H1}-a")), full(&format!("{H2}-b"))];
-        t.db.invalidate_paths(dead.iter().map(|s| s.as_str()))
-            .unwrap();
+        t.db.invalidate_ids([a, b].into_iter()).unwrap();
 
         for table in ["Realisations", "RealisationsRefs", "ValidPaths"] {
             let n: i64 =

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -436,7 +436,7 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         // Invalidate rows before unlinking: builders trust isValidPath(),
         // so a path must never look valid after its disk entry is gone.
         // See alloy/gc_db_consistency.als.
-        db.invalidate_paths(claimed.iter().map(|&n| graph.paths[n as usize].as_str()))?;
+        db.invalidate_ids(claimed.iter().map(|&n| graph.ids[n as usize]))?;
         claimed.par_iter().for_each(|&node| {
             let path = &graph.paths[node as usize];
             let basename = path.strip_prefix(&store_prefix).unwrap_or(path);

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -357,29 +357,51 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     let bytes_freed = AtomicU64::new(0);
     let paths_deleted = AtomicU64::new(0);
 
-    // Reverse edges among dead paths. A chunk has to take the dead
-    // referrers of everything it invalidates with it, otherwise a
-    // surviving row keeps references to deleted rows. Only needed when
-    // --ensure-free splits deletion into chunks; a single chunk is the
-    // whole dead set. Alive paths never reference dead ones.
-    let dead_referrers: Option<Vec<Vec<u32>>> = max_freed.map(|_| {
-        let mut rev = vec![Vec::new(); graph.len()];
-        for &n in &dead_indices {
-            for &m in graph.refs(n) {
-                if !alive[m as usize] && m != n {
-                    rev[m as usize].push(n);
-                }
+    // Referrer-first deletion order (Kahn over the dead subgraph), so
+    // every prefix is safe to commit: still-valid paths never reference an
+    // already-deleted one. in_degree counts a dead node's dead referrers
+    // (graph.refs(r) lists what r references, so an edge r->m makes r a
+    // referrer of m).
+    let dead_ref = |node: u32, m: u32| m != node && !alive[m as usize];
+    let mut in_degree = vec![0u32; graph.len()];
+    for &node in &dead_indices {
+        for &m in graph.refs(node).iter().filter(|&&m| dead_ref(node, m)) {
+            in_degree[m as usize] += 1;
+        }
+    }
+    let mut order: Vec<u32> = dead_indices
+        .iter()
+        .copied()
+        .filter(|&m| in_degree[m as usize] == 0)
+        .collect();
+    let mut head = 0;
+    while head < order.len() {
+        let node = order[head];
+        head += 1;
+        for &m in graph.refs(node).iter().filter(|&&m| dead_ref(node, m)) {
+            in_degree[m as usize] -= 1;
+            if in_degree[m as usize] == 0 {
+                order.push(m);
             }
         }
-        rev
-    });
+    }
+    // Cyclic nodes never reach in-degree 0. They are mutually dependent,
+    // so they share one trailing chunk that is never split.
+    let acyclic_len = order.len();
+    if order.len() < dead_indices.len() {
+        order.extend(
+            dead_indices
+                .iter()
+                .copied()
+                .filter(|&m| in_degree[m as usize] != 0),
+        );
+    }
 
-    // Fill each chunk by cumulative narSize up to the remaining --ensure-free
-    // budget, then re-check actual freed bytes (narSize over-reports for
-    // hard-linked paths). Without --ensure-free, max is u64::MAX: one chunk.
-    let mut in_chunk = vec![false; graph.len()];
+    // Commit in bounded chunks, truncating the WAL after each, so disk use
+    // stays bounded and space is reclaimed incrementally.
+    const MAX_CHUNK: usize = 65_536;
     let mut cursor = 0usize;
-    while cursor < dead_indices.len() {
+    while cursor < order.len() {
         let freed_so_far = bytes_freed.load(Ordering::Relaxed);
         if freed_so_far >= max {
             log::info!("deleted more than {max} bytes; stopping");
@@ -387,31 +409,22 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         }
         let remaining = max - freed_so_far;
         let mut chunk: Vec<u32> = Vec::new();
+        // narSize over-reports hard-linked paths, so estimated only
+        // bounds the chunk; actual freed bytes are re-checked above.
         let mut estimated = 0u64;
-        while cursor < dead_indices.len() && estimated < remaining {
-            let n = dead_indices[cursor];
+        // Take the cyclic tail (from acyclic_len on) whole and unsplit.
+        let take_all = cursor >= acyclic_len;
+        while cursor < order.len()
+            && (take_all
+                || (cursor < acyclic_len && estimated < remaining && chunk.len() < MAX_CHUNK))
+        {
+            let node = order[cursor];
             cursor += 1;
-            if !in_chunk[n as usize] {
-                in_chunk[n as usize] = true;
-                estimated = estimated.saturating_add(graph.nar_sizes[n as usize]);
-                chunk.push(n);
-            }
+            estimated = estimated.saturating_add(graph.nar_sizes[node as usize]);
+            chunk.push(node);
         }
         if chunk.is_empty() {
             break;
-        }
-        // Close the chunk under dead referrers (see dead_referrers above).
-        if let Some(rev) = &dead_referrers {
-            let mut i = 0;
-            while i < chunk.len() {
-                for &r in &rev[chunk[i] as usize] {
-                    if !in_chunk[r as usize] {
-                        in_chunk[r as usize] = true;
-                        chunk.push(r);
-                    }
-                }
-                i += 1;
-            }
         }
         // Claim (mark pending) atomically with the protection check,
         // *before* invalidating DB rows. A protect() arriving later for a
@@ -452,7 +465,13 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
             }
             live.end_delete_node(node);
         });
-        paths_deleted.fetch_add(claimed.len() as u64, Ordering::Relaxed);
+        let done =
+            paths_deleted.fetch_add(claimed.len() as u64, Ordering::Relaxed) + claimed.len() as u64;
+        log::debug!(
+            "deleted {done}/{} dead paths, {} freed",
+            order.len(),
+            format_size(bytes_freed.load(Ordering::Relaxed)),
+        );
     }
 
     // Unknown-on-disk paths: also parallel. tmp-* dirs hold flock through

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -127,6 +127,10 @@ pub struct GcOptions {
     /// readers keep the VACUUM's database-sized WAL from being
     /// truncated (the problem behind Nix commit 8299aaf).
     pub no_vacuum: bool,
+    /// Max dead paths invalidated per DB transaction. Smaller keeps the
+    /// WAL (and its disk use) lower; larger means fewer checkpoints.
+    /// None uses the default.
+    pub chunk_size: Option<usize>,
 }
 
 /// Main GC: find roots, compute alive closure, delete dead paths.
@@ -399,7 +403,7 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
 
     // Commit in bounded chunks, truncating the WAL after each, so disk use
     // stays bounded and space is reclaimed incrementally.
-    const MAX_CHUNK: usize = 65_536;
+    let max_chunk = opts.chunk_size.unwrap_or(65_536).max(1);
     let mut cursor = 0usize;
     while cursor < order.len() {
         let freed_so_far = bytes_freed.load(Ordering::Relaxed);
@@ -416,7 +420,7 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
         let take_all = cursor >= acyclic_len;
         while cursor < order.len()
             && (take_all
-                || (cursor < acyclic_len && estimated < remaining && chunk.len() < MAX_CHUNK))
+                || (cursor < acyclic_len && estimated < remaining && chunk.len() < max_chunk))
         {
             let node = order[cursor];
             cursor += 1;

--- a/crates/gc/src/gc_socket.rs
+++ b/crates/gc/src/gc_socket.rs
@@ -379,6 +379,7 @@ mod tests {
         }
         StoreGraph {
             paths: paths.iter().map(|(p, _)| format!("{prefix}{p}")).collect(),
+            ids: (0..n as i64).collect(),
             nar_sizes: vec![0; n],
             registration_times: vec![0; n],
             ref_offsets,

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -11,6 +11,7 @@ struct Args {
     ensure_free: Option<u64>,
     keep_recent: Option<String>,
     no_vacuum: bool,
+    chunk_size: Option<usize>,
     keep_outputs: Option<bool>,
     keep_derivations: Option<bool>,
     store_dir: PathBuf,
@@ -59,6 +60,9 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         println!("      --ensure-free SIZE        Free until SIZE is available (e.g. 50G)");
         println!("      --keep-recent SPEC        Keep paths registered within SPEC (e.g. 7d)");
         println!("      --no-vacuum               Skip the database VACUUM after deletion");
+        println!(
+            "      --chunk-size N            Dead paths per delete transaction [default: 65536]"
+        );
         println!("      --keep-outputs BOOL       Override the keep-outputs nix.conf setting");
         println!("      --keep-derivations BOOL   Override the keep-derivations nix.conf setting");
         println!("      --store-dir PATH          Nix store directory [default: /nix/store]");
@@ -77,6 +81,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         ensure_free: pargs.opt_value_from_fn("--ensure-free", parse_size)?,
         keep_recent: pargs.opt_value_from_str("--keep-recent")?,
         no_vacuum: pargs.contains("--no-vacuum"),
+        chunk_size: pargs.opt_value_from_str("--chunk-size")?,
         keep_outputs: pargs.opt_value_from_str("--keep-outputs")?,
         keep_derivations: pargs.opt_value_from_str("--keep-derivations")?,
         store_dir: pargs
@@ -98,6 +103,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
             "--ensure-free",
             "--keep-recent",
             "--no-vacuum",
+            "--chunk-size",
             "--keep-outputs",
             "--keep-derivations",
             "--store-dir",
@@ -191,6 +197,7 @@ fn main() -> Result<()> {
         max_freed,
         keep_recent_after,
         no_vacuum: args.no_vacuum,
+        chunk_size: args.chunk_size,
     };
     let (bytes_freed, paths_deleted) = gc::collect_garbage(&store, &opts)?;
 

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -503,6 +503,39 @@ fn gc_max_freed_referrer_never_outlives_reference() {
 }
 
 #[test]
+fn gc_chunk_size_one_deletes_whole_dead_chain() {
+    use fast_nix_gc::{
+        db::NixDb,
+        gc::{GcOptions, collect_garbage},
+    };
+    let store = TestStore::new();
+    // A reference chain a -> b -> c, all dead. With one path per
+    // transaction, referrer-first order must still delete every node and
+    // never leave a surviving referrer pointing at a deleted reference.
+    let c = store.add_path("dead-c", 100);
+    let b = store.add_path("dead-b", 100);
+    let a = store.add_path("dead-a", 100);
+    store.add_ref(&a, &b);
+    store.add_ref(&b, &c);
+
+    let nix_db = NixDb::open(&store.store_dir, &store.state_dir).unwrap();
+    let opts = GcOptions {
+        chunk_size: Some(1),
+        ..Default::default()
+    };
+    collect_garbage(&nix_db, &opts).unwrap();
+
+    for p in [&a, &b, &c] {
+        assert!(!p.path.exists(), "{} should be GC'd", p.full);
+    }
+    let conn = store.db();
+    let remaining: i64 = conn
+        .query_row("SELECT COUNT(*) FROM ValidPaths", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(remaining, 0, "all dead paths should be invalidated");
+}
+
+#[test]
 fn gc_keep_recent_pins_recently_registered() {
     use fast_nix_gc::{
         db::NixDb,

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -83,6 +83,16 @@ in
       '';
     };
 
+    chunkSize = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      description = ''
+        Number of dead paths invalidated per database transaction. Lower
+        values keep the WAL (and its disk use) smaller during deletion at
+        the cost of more checkpoints; null uses the default (65536).
+      '';
+    };
+
     extraArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -185,6 +195,10 @@ in
               cfg.keepRecent
             ]
             ++ lib.optional cfg.noVacuum "--no-vacuum"
+            ++ lib.optionals (cfg.chunkSize != null) [
+              "--chunk-size"
+              (toString cfg.chunkSize)
+            ]
             ++ cfg.extraArgs
           );
         };

--- a/proptest/proptest_gc.rs
+++ b/proptest/proptest_gc.rs
@@ -156,15 +156,16 @@ proptest! {
         }
 
         // Invalidation must not violate FK constraints (cycles etc.)
-        let dead_paths: Vec<String> = (0..n)
+        let dead_ids: Vec<i64> = (0..n)
             .filter(|&i| !expected[i])
-            .map(|i| {
+            .filter_map(|i| {
                 let hash = fake_hash(i);
-                format!("{}/{hash}-pkg-{i}", store_dir.display())
+                let full = format!("{}/{hash}-pkg-{i}", store_dir.display());
+                bidx.idx_of(&full).map(|idx| graph.ids[idx as usize])
             })
             .collect();
 
-        db.invalidate_paths(dead_paths.iter().map(|s| s.as_str())).unwrap();
+        db.invalidate_ids(dead_ids.into_iter()).unwrap();
 
         // Verify DB state
         let remaining: Vec<String> = {


### PR DESCRIPTION
This is the result of running gc on hydra.nixos.org freeing up a TB of nix store with a sqlite db that grew to 58GB.