### PR TITLE
Add nix to fast-nix-optimise PATH, too

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -229,6 +229,8 @@ in
 
       systemd.services.fast-nix-optimise = {
         description = "Fast Nix Store Optimiser";
+        # `nix config show` for keep-derivations/keep-outputs.
+        path = [ config.nix.package ];
         serviceConfig = {
           Type = "oneshot";
           ExecStart = lib.escapeShellArgs (


### PR DESCRIPTION
fast-nix-optimise[13308]: [INFO ] remounted /nix/store read-write
fast-nix-optimise[13308]: [WARN ] cannot run `nix config show keep-derivations`: No such file or directory (os error 2); using default true
fast-nix-optimise[13308]: [WARN ] cannot run `nix config show keep-outputs`: No such file or directory (os error 2); using default false
fast-nix-optimise[13308]: [INFO ] optimising 108498 store paths