### PR TITLE
gc: accept percentage values for --ensure-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ fast-nix-gc [OPTIONS]
   -d, --delete-old              Remove old profile generations
       --delete-older-than SPEC  Delete generations older than SPEC (e.g. 30d, 4h)
       --dry-run                 Show what would be done
-      --ensure-free SIZE        Free until SIZE is available (e.g. 50G)
+      --ensure-free SIZE        Free until SIZE is available (e.g. 50G or 20%)
       --keep-recent SPEC        Keep paths registered within SPEC (e.g. 1d)
       --no-vacuum               Skip the database VACUUM after deletion
       --chunk-size N            Dead paths per delete transaction [default: 65536]
@@ -96,7 +96,7 @@ Replaces `nix.gc` and `nix.optimise`:
 | `randomizedDelaySec` | `"0"` | Random delay before each run |
 | `persistent` | `true` | Run on next boot if a scheduled run was missed |
 | `deleteOlderThan` | `null` | Remove profile generations older than e.g. `"30d"` |
-| `ensureFree` | `null` | Stop once this much disk is free, e.g. `"50G"` |
+| `ensureFree` | `null` | Stop once this much disk is free, e.g. `"50G"` or `"20%"` of the store's filesystem |
 | `keepRecent` | `null` | Pin paths registered within e.g. `"1d"` |
 | `noVacuum` | `false` | Skip the post-GC database VACUUM (see below) |
 | `chunkSize` | `null` | Dead paths per delete transaction (default 65536) |

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -8,7 +8,7 @@ struct Args {
     delete_old: bool,
     delete_older_than: Option<String>,
     dry_run: bool,
-    ensure_free: Option<u64>,
+    ensure_free: Option<EnsureFree>,
     keep_recent: Option<String>,
     no_vacuum: bool,
     chunk_size: Option<usize>,
@@ -16,6 +16,40 @@ struct Args {
     keep_derivations: Option<bool>,
     store_dir: PathBuf,
     state_dir: PathBuf,
+}
+
+/// `--ensure-free` target: absolute bytes or a percentage of the store's
+/// filesystem.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum EnsureFree {
+    Bytes(u64),
+    Percent(f64),
+}
+
+impl EnsureFree {
+    fn target_bytes(self, total: u64) -> u64 {
+        match self {
+            EnsureFree::Bytes(b) => b,
+            EnsureFree::Percent(p) => (total as f64 * p / 100.0) as u64,
+        }
+    }
+}
+
+/// Parse a size like "50G" or a percentage like "20%".
+fn parse_ensure_free(s: &str) -> Result<EnsureFree> {
+    let s = s.trim();
+    if let Some(num) = s.strip_suffix('%') {
+        let p: f64 = num
+            .trim()
+            .parse()
+            .with_context(|| format!("invalid percentage '{s}'"))?;
+        if !p.is_finite() || !(0.0..=100.0).contains(&p) {
+            bail!("percentage '{s}' must be between 0 and 100");
+        }
+        Ok(EnsureFree::Percent(p))
+    } else {
+        Ok(EnsureFree::Bytes(parse_size(s)?))
+    }
 }
 
 /// Parse a size like "50G", "512M", "1024K", or plain bytes.
@@ -35,12 +69,15 @@ fn parse_size(s: &str) -> Result<u64> {
     Ok((n * mult as f64) as u64)
 }
 
-/// Free bytes on the filesystem containing `path`.
-fn available_bytes(path: &Path) -> Result<u64> {
+/// Free and total bytes on the filesystem containing `path`.
+fn filesystem_bytes(path: &Path) -> Result<(u64, u64)> {
     let st =
         nix::sys::statvfs::statvfs(path).with_context(|| format!("statvfs {}", path.display()))?;
     // statvfs field types differ between Linux (u64) and macOS (u32).
-    Ok(st.blocks_available() as u64 * st.fragment_size() as u64)
+    let frag = st.fragment_size() as u64;
+    let avail = st.blocks_available() as u64 * frag;
+    let total = st.blocks() as u64 * frag;
+    Ok((avail, total))
 }
 
 fn parse_args() -> Result<Args> {
@@ -57,7 +94,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         println!("  -d, --delete-old              Remove old profile generations");
         println!("      --delete-older-than SPEC  Delete generations older than SPEC (e.g. 30d)");
         println!("      --dry-run                 Show what would be done");
-        println!("      --ensure-free SIZE        Free until SIZE is available (e.g. 50G)");
+        println!("      --ensure-free SIZE        Free until SIZE is available (e.g. 50G or 20%)");
         println!("      --keep-recent SPEC        Keep paths registered within SPEC (e.g. 7d)");
         println!("      --no-vacuum               Skip the database VACUUM after deletion");
         println!(
@@ -78,7 +115,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         delete_old,
         delete_older_than,
         dry_run: pargs.contains("--dry-run"),
-        ensure_free: pargs.opt_value_from_fn("--ensure-free", parse_size)?,
+        ensure_free: pargs.opt_value_from_fn("--ensure-free", parse_ensure_free)?,
         keep_recent: pargs.opt_value_from_str("--keep-recent")?,
         no_vacuum: pargs.contains("--no-vacuum"),
         chunk_size: pargs.opt_value_from_str("--chunk-size")?,
@@ -158,8 +195,9 @@ fn main() -> Result<()> {
             })?;
     }
 
-    let max_freed = if let Some(target) = args.ensure_free {
-        let avail = available_bytes(&args.store_dir)?;
+    let max_freed = if let Some(ensure_free) = args.ensure_free {
+        let (avail, total) = filesystem_bytes(&args.store_dir)?;
+        let target = ensure_free.target_bytes(total);
         if avail >= target {
             println!("{} already free, nothing to do", format_size(avail));
             return Ok(());
@@ -218,7 +256,7 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_args_from, parse_size};
+    use super::{EnsureFree, parse_args_from, parse_ensure_free, parse_size};
 
     fn args(list: &[&str]) -> Vec<std::ffi::OsString> {
         list.iter().map(|s| s.into()).collect()
@@ -255,5 +293,26 @@ mod tests {
         assert!(parse_size("inf").is_err());
         assert!(parse_size("NaN").is_err());
         assert!(parse_size("99999999999999999999G").is_err());
+    }
+
+    #[test]
+    fn parse_ensure_free_values() {
+        assert_eq!(
+            parse_ensure_free("50G").unwrap(),
+            EnsureFree::Bytes(50 * 1024u64.pow(3))
+        );
+        assert_eq!(parse_ensure_free("1024").unwrap(), EnsureFree::Bytes(1024));
+        assert_eq!(parse_ensure_free("20%").unwrap(), EnsureFree::Percent(20.0));
+        assert_eq!(
+            parse_ensure_free(" 12.5 % ").unwrap(),
+            EnsureFree::Percent(12.5)
+        );
+        assert_eq!(
+            parse_ensure_free("100%").unwrap(),
+            EnsureFree::Percent(100.0)
+        );
+        assert!(parse_ensure_free("101%").is_err());
+        assert!(parse_ensure_free("-5%").is_err());
+        assert!(parse_ensure_free("abc%").is_err());
     }
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -60,7 +60,11 @@ in
       type = lib.types.nullOr lib.types.singleLineStr;
       default = null;
       example = "50G";
-      description = "Free space until this much is available, then stop.";
+      description = ''
+        Free space until this much is available, then stop. Accepts an
+        absolute size like "50G" or a percentage of the store's filesystem
+        like "20%".
+      '';
     };
 
     keepRecent = lib.mkOption {


### PR DESCRIPTION

Sharing one GC config across machines with different disk sizes needs an
absolute --ensure-free per host. Accept "20%" so a single value resolves
against the total size of the filesystem backing --store-dir.
