### PR TITLE
gc: extra GC root dirs + nix-darwin module + CI activation

### DIFF
--- a/.github/workflows/darwin-module.yaml
+++ b/.github/workflows/darwin-module.yaml
@@ -1,0 +1,42 @@
+name: Darwin module
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+  checks: read
+jobs:
+  darwin-module:
+    # macos-latest is arm64 -> aarch64-darwin
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Wait for nixbot (buildbot) to finish so we don't duplicate work or
+      # run before the main eval has passed. Runs in the PR's own
+      # unprivileged context, so no secrets/cache exposure for fork PRs.
+      - name: Wait for nixbot
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/wait-for-buildbot.sh "${{ github.event.pull_request.head.sha || github.sha }}"
+      - uses: NixOS/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://cache.thalheim.io
+            extra-trusted-public-keys = cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc=
+      - uses: Mic92/hestia@v1
+      # Build coverage: evaluates the module and builds the system closure.
+      - run: nix build --print-build-logs '.#checks.aarch64-darwin.darwin-module'
+      # nix-darwin refuses to overwrite the runner's pre-existing shell
+      # rc files; mark them as backups so activation can take over.
+      - name: Prepare /etc for nix-darwin
+        run: |
+          for f in /etc/bashrc /etc/zshrc /etc/zshenv /etc/bash.bashrc; do
+            [ -e "$f" ] && sudo mv "$f" "$f.before-nix-darwin" || true
+          done
+      # Activation coverage: install the launchd daemons on the runner.
+      - run: sudo nix run github:nix-darwin/nix-darwin -- switch --flake '.#ci'
+      - name: Verify launchd daemons are loaded
+        run: |
+          sudo launchctl print system/org.nixos.fast-nix-gc
+          sudo launchctl print system/org.nixos.fast-nix-optimise

--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ Replaces `nix.gc` and `nix.optimise`:
 
 Without flakes, import `nix/module.nix` directly.
 
+### nix-darwin
+
+`darwinModules.default` exposes the same `services.fast-nix-gc` and
+`services.fast-nix-optimise` options, run as launchd daemons. Scheduling
+uses launchd's `startCalendarInterval` (a list of
+`launchd.plist(5)` StartCalendarInterval entries) instead of `dates`:
+
+```nix
+fast-nix-gc.darwinModules.default
+{
+  services.fast-nix-gc = {
+    enable = true;
+    automatic = true;
+    startCalendarInterval = [ { Hour = 3; Minute = 15; } ];
+    deleteOlderThan = "30d";
+    ensureFree = "50G";
+  };
+}
+```
+
 ### When to use `--no-vacuum` / `noVacuum`
 
 After deleting dead paths, fast-nix-gc runs `VACUUM` when at least a

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ fast-nix-gc [OPTIONS]
       --chunk-size N            Dead paths per delete transaction [default: 65536]
       --keep-outputs BOOL       Override the keep-outputs nix.conf setting
       --keep-derivations BOOL   Override the keep-derivations nix.conf setting
+      --gc-roots-dir PATH       Extra directory to scan for GC roots (repeatable)
       --store-dir PATH          Nix store directory [default: /nix/store]
       --state-dir PATH          Nix state directory [default: /nix/var/nix]
 ```
@@ -100,6 +101,7 @@ Replaces `nix.gc` and `nix.optimise`:
 | `keepRecent` | `null` | Pin paths registered within e.g. `"1d"` |
 | `noVacuum` | `false` | Skip the post-GC database VACUUM (see below) |
 | `chunkSize` | `null` | Dead paths per delete transaction (default 65536) |
+| `gcRootsDirs` | `[ ]` | Extra directories to scan for GC roots, e.g. `[ "/mnt/extra-roots" ]` |
 | `package` | this flake's package | Override the binary |
 | `extraArgs` | `[ ]` | Extra CLI arguments |
 

--- a/crates/gc/src/gc.rs
+++ b/crates/gc/src/gc.rs
@@ -131,6 +131,9 @@ pub struct GcOptions {
     /// WAL (and its disk use) lower; larger means fewer checkpoints.
     /// None uses the default.
     pub chunk_size: Option<usize>,
+    /// Extra directories scanned for GC roots, like `gcroots`. Nix only
+    /// scans its fixed state dirs, so roots outside them go uncounted.
+    pub extra_gc_roots_dirs: Vec<std::path::PathBuf>,
 }
 
 /// Main GC: find roots, compute alive closure, delete dead paths.
@@ -227,7 +230,12 @@ pub fn collect_garbage(db: &NixDb, opts: &GcOptions) -> Result<(u64, usize)> {
     }
 
     log::info!("finding garbage collector roots...");
-    let mut roots = find_roots(&db.state_dir, &db.store_dir, &bidx)?;
+    let mut roots = find_roots(
+        &db.state_dir,
+        &db.store_dir,
+        &opts.extra_gc_roots_dirs,
+        &bidx,
+    )?;
     roots.extend(early_root_idxs);
 
     // Add temp roots. Some may reference paths registered after our

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -14,6 +14,7 @@ struct Args {
     chunk_size: Option<usize>,
     keep_outputs: Option<bool>,
     keep_derivations: Option<bool>,
+    gc_roots_dirs: Vec<PathBuf>,
     store_dir: PathBuf,
     state_dir: PathBuf,
 }
@@ -102,6 +103,9 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         );
         println!("      --keep-outputs BOOL       Override the keep-outputs nix.conf setting");
         println!("      --keep-derivations BOOL   Override the keep-derivations nix.conf setting");
+        println!(
+            "      --gc-roots-dir PATH       Extra directory to scan for GC roots (repeatable)"
+        );
         println!("      --store-dir PATH          Nix store directory [default: /nix/store]");
         println!("      --state-dir PATH          Nix state directory [default: /nix/var/nix]");
         std::process::exit(0);
@@ -121,6 +125,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         chunk_size: pargs.opt_value_from_str("--chunk-size")?,
         keep_outputs: pargs.opt_value_from_str("--keep-outputs")?,
         keep_derivations: pargs.opt_value_from_str("--keep-derivations")?,
+        gc_roots_dirs: pargs.values_from_str("--gc-roots-dir")?,
         store_dir: pargs
             .opt_value_from_str("--store-dir")?
             .unwrap_or_else(|| PathBuf::from("/nix/store")),
@@ -143,6 +148,7 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
             "--chunk-size",
             "--keep-outputs",
             "--keep-derivations",
+            "--gc-roots-dir",
             "--store-dir",
             "--state-dir",
             "--help",
@@ -236,6 +242,7 @@ fn main() -> Result<()> {
         keep_recent_after,
         no_vacuum: args.no_vacuum,
         chunk_size: args.chunk_size,
+        extra_gc_roots_dirs: args.gc_roots_dirs,
     };
     let (bytes_freed, paths_deleted) = gc::collect_garbage(&store, &opts)?;
 

--- a/crates/gc/src/roots.rs
+++ b/crates/gc/src/roots.rs
@@ -5,18 +5,24 @@ use crate::HashSet;
 use crate::db::BasenameIndex;
 use anyhow::{Context, Result};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Find all GC root node indices by walking gcroots/profiles directories
-/// and scanning running processes.
-pub fn find_roots(state_dir: &Path, store_dir: &Path, idx: &BasenameIndex) -> Result<Vec<u32>> {
+/// (plus any `extra_dirs`) and scanning running processes.
+pub fn find_roots(
+    state_dir: &Path,
+    store_dir: &Path,
+    extra_dirs: &[PathBuf],
+    idx: &BasenameIndex,
+) -> Result<Vec<u32>> {
     let mut roots = HashSet::default();
     let store_prefix = store_dir.to_string_lossy().to_string();
 
     // Errors here must abort the GC: silently dropping a roots directory
     // (e.g. EACCES) would let the GC delete live paths.
-    for dir in [state_dir.join("gcroots"), state_dir.join("profiles")] {
-        find_roots_in_dir(&dir, &store_prefix, idx, &mut roots)
+    let default_dirs = [state_dir.join("gcroots"), state_dir.join("profiles")];
+    for dir in default_dirs.iter().chain(extra_dirs.iter()) {
+        find_roots_in_dir(dir, &store_prefix, idx, &mut roots)
             .with_context(|| format!("scanning roots in {}", dir.display()))?;
     }
 
@@ -738,8 +744,47 @@ pub fn find_temp_roots(state_dir: &Path) -> Result<HashSet<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::{BasenameIndex, StoreGraph};
 
     const HASH: &str = "abcdefghijklmnopqrstuvwxyz012345"; // 32 chars
+
+    fn graph(paths: &[&str]) -> StoreGraph {
+        let n = paths.len();
+        StoreGraph {
+            paths: paths.iter().map(|p| format!("/nix/store/{p}")).collect(),
+            ids: (0..n as i64).collect(),
+            nar_sizes: vec![0; n],
+            registration_times: vec![0; n],
+            ref_offsets: vec![0; n + 1],
+            ref_targets: Vec::new(),
+            store_prefix: "/nix/store/".to_owned(),
+        }
+    }
+
+    #[test]
+    fn find_roots_scans_extra_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state");
+        fs::create_dir_all(state.join("gcroots")).unwrap();
+        fs::create_dir_all(state.join("profiles")).unwrap();
+        let extra = tmp.path().join("extra-roots");
+        fs::create_dir_all(&extra).unwrap();
+
+        let target = format!("/nix/store/{HASH}-foo");
+        std::os::unix::fs::symlink(&target, extra.join("link")).unwrap();
+
+        let g = graph(&[&format!("{HASH}-foo")]);
+        let idx = BasenameIndex::new(&g);
+        let store_dir = Path::new("/nix/store");
+
+        // Without the extra dir the symlink is invisible.
+        let roots = find_roots(&state, store_dir, &[], &idx).unwrap();
+        assert!(roots.is_empty(), "{roots:?}");
+
+        // With it, the symlink target becomes a root.
+        let roots = find_roots(&state, store_dir, &[extra], &idx).unwrap();
+        assert_eq!(roots, vec![0], "{roots:?}");
+    }
 
     #[test]
     fn store_path_basename_grammar() {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782175435,
@@ -18,6 +38,7 @@
     },
     "root": {
       "inputs": {
+        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,17 @@
     url = "github:numtide/treefmt-nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
+  inputs.nix-darwin = {
+    url = "github:nix-darwin/nix-darwin";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
 
   outputs =
     {
       self,
       nixpkgs,
       treefmt-nix,
+      nix-darwin,
       ...
     }:
     let
@@ -42,6 +47,14 @@
       nixosModules.default = ./nix/module.nix;
       darwinModules.default = ./nix/darwin-module.nix;
 
+      # Activated on a macOS runner; see the darwin-module workflow.
+      darwinConfigurations.ci = import ./nix/darwin-test.nix {
+        system = "aarch64-darwin";
+        darwin = nix-darwin;
+        darwinModule = self.darwinModules.default;
+        activate = true;
+      };
+
       checks = forAllSystems (
         system:
         let
@@ -55,6 +68,14 @@
         // nixpkgs.lib.mapAttrs' (n: nixpkgs.lib.nameValuePair "devshell-${n}") self.devShells.${system}
         // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           nixos-test = import ./nix/nixos-test.nix { inherit pkgs; };
+        }
+        // nixpkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          darwin-module =
+            (import ./nix/darwin-test.nix {
+              inherit system;
+              darwin = nix-darwin;
+              darwinModule = self.darwinModules.default;
+            }).system;
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
       );
 
       nixosModules.default = ./nix/module.nix;
+      darwinModules.default = ./nix/darwin-module.nix;
 
       checks = forAllSystems (
         system:

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
   };
 
   outputs =
-    {
+    inputs@{
       self,
       nixpkgs,
       treefmt-nix,
@@ -63,6 +63,10 @@
         {
           proptest = pkgs.callPackage ./nix/proptest.nix { };
           treefmt = (import ./nix/treefmt.nix { inherit pkgs treefmt-nix; }).config.build.check ./.;
+          # Realize the flake inputs so the binary cache holds their
+          # source trees; later runs fetch from the cache instead of
+          # re-downloading.
+          flake-inputs = pkgs.linkFarm "flake-inputs" (builtins.removeAttrs inputs [ "self" ]);
         }
         // nixpkgs.lib.mapAttrs' (n: nixpkgs.lib.nameValuePair "package-${n}") self.packages.${system}
         // nixpkgs.lib.mapAttrs' (n: nixpkgs.lib.nameValuePair "devshell-${n}") self.devShells.${system}

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -70,8 +70,12 @@ in
         StartCalendarInterval = lib.mkIf cfg.automatic cfg.startCalendarInterval;
         # `nix config show` for keep-derivations/keep-outputs. Raw
         # ProgramArguments bypass nix-darwin's `path` wrapper, so put nix
-        # on PATH explicitly.
-        EnvironmentVariables.PATH = "${config.nix.package}/bin";
+        # on PATH explicitly. When nix-darwin does not manage nix (an
+        # external installer), config.nix.package is unavailable, so fall
+        # back to the standard profile/installer locations.
+        EnvironmentVariables.PATH =
+          lib.optionalString config.nix.enable "${config.nix.package}/bin:"
+          + "/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin";
       };
     })
 

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.fast-nix-gc;
+  ocfg = config.services.fast-nix-optimise;
+in
+{
+  imports = [ ./service-options.nix ];
+
+  options.services.fast-nix-gc.startCalendarInterval = lib.mkOption {
+    type = with lib.types; listOf (attrsOf int);
+    default = [
+      {
+        Hour = 3;
+        Minute = 15;
+      }
+    ];
+    example = [
+      {
+        Hour = 3;
+        Minute = 15;
+      }
+    ];
+    description = ''
+      When to run garbage collection, as launchd
+      {manpage}`launchd.plist(5)` StartCalendarInterval entries.
+    '';
+  };
+
+  options.services.fast-nix-optimise.startCalendarInterval = lib.mkOption {
+    type = with lib.types; listOf (attrsOf int);
+    default = [
+      {
+        Hour = 4;
+        Minute = 15;
+      }
+    ];
+    example = [
+      {
+        Hour = 4;
+        Minute = 15;
+      }
+    ];
+    description = ''
+      When to run, as launchd {manpage}`launchd.plist(5)`
+      StartCalendarInterval entries.
+    '';
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = cfg.automatic -> config.nix.enable;
+          message = "services.fast-nix-gc.automatic requires nix.enable";
+        }
+      ];
+
+      warnings = lib.optional (cfg.automatic && config.nix.gc.automatic) ''
+        Both services.fast-nix-gc.automatic and nix.gc.automatic are enabled.
+        Disable nix.gc.automatic to avoid running two garbage collectors.
+      '';
+
+      launchd.daemons.fast-nix-gc.serviceConfig = {
+        ProgramArguments = cfg.argv;
+        RunAtLoad = false;
+        StartCalendarInterval = lib.mkIf cfg.automatic cfg.startCalendarInterval;
+        # `nix config show` for keep-derivations/keep-outputs. Raw
+        # ProgramArguments bypass nix-darwin's `path` wrapper, so put nix
+        # on PATH explicitly.
+        EnvironmentVariables.PATH = "${config.nix.package}/bin";
+      };
+    })
+
+    (lib.mkIf ocfg.enable {
+      assertions = [
+        {
+          assertion = ocfg.automatic -> config.nix.enable;
+          message = "services.fast-nix-optimise.automatic requires nix.enable";
+        }
+      ];
+
+      warnings = lib.optional (ocfg.automatic && config.nix.optimise.automatic) ''
+        Both services.fast-nix-optimise.automatic and nix.optimise.automatic are
+        enabled. Disable nix.optimise.automatic to avoid running both.
+      '';
+
+      launchd.daemons.fast-nix-optimise.serviceConfig = {
+        ProgramArguments = ocfg.argv;
+        RunAtLoad = false;
+        StartCalendarInterval = lib.mkIf ocfg.automatic ocfg.startCalendarInterval;
+      };
+    })
+  ];
+}

--- a/nix/darwin-test.nix
+++ b/nix/darwin-test.nix
@@ -1,0 +1,45 @@
+# A minimal nix-darwin system that enables both services through
+# darwinModules.default. Used two ways (see flake.nix):
+#   - checks.<darwin>.darwin-module builds .system (eval + build coverage)
+#   - darwinConfigurations.ci is activated on a macOS runner
+#     (.github/workflows/darwin-module.yaml)
+#
+# When activate is set we keep nix-darwin from managing nix.conf, since CI
+# installs Nix with an external installer; that in turn disables the
+# scheduled timers (the module asserts automatic -> nix.enable).
+{
+  darwin,
+  darwinModule,
+  system,
+  activate ? false,
+}:
+darwin.lib.darwinSystem {
+  inherit system;
+  modules = [
+    darwinModule
+    {
+      system.stateVersion = 5;
+      system.primaryUser = "runner";
+      nix.enable = !activate;
+
+      services.fast-nix-gc = {
+        enable = true;
+        automatic = !activate;
+        startCalendarInterval = [
+          {
+            Hour = 3;
+            Minute = 15;
+          }
+        ];
+        deleteOlderThan = "30d";
+        ensureFree = "20%";
+        gcRootsDirs = [ "/mnt/extra-roots" ];
+      };
+
+      services.fast-nix-optimise = {
+        enable = true;
+        automatic = !activate;
+      };
+    }
+  ];
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
@@ -9,22 +8,9 @@ let
   ocfg = config.services.fast-nix-optimise;
 in
 {
+  imports = [ ./service-options.nix ];
+
   options.services.fast-nix-gc = {
-    enable = lib.mkEnableOption "fast-nix-gc, a faster nix-collect-garbage";
-
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.callPackage ./package.nix { };
-      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix { }";
-      description = "fast-nix-gc package to use.";
-    };
-
-    automatic = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Run garbage collection automatically on a schedule.";
-    };
-
     dates = lib.mkOption {
       type = with lib.types; either singleLineStr (listOf str);
       apply = lib.toList;
@@ -48,78 +34,9 @@ in
       default = true;
       description = "Run on next boot if a scheduled run was missed.";
     };
-
-    deleteOlderThan = lib.mkOption {
-      type = lib.types.nullOr lib.types.singleLineStr;
-      default = null;
-      example = "30d";
-      description = "Delete profile generations older than this.";
-    };
-
-    ensureFree = lib.mkOption {
-      type = lib.types.nullOr lib.types.singleLineStr;
-      default = null;
-      example = "50G";
-      description = ''
-        Free space until this much is available, then stop. Accepts an
-        absolute size like "50G" or a percentage of the store's filesystem
-        like "20%".
-      '';
-    };
-
-    keepRecent = lib.mkOption {
-      type = lib.types.nullOr lib.types.singleLineStr;
-      default = null;
-      example = "1d";
-      description = ''
-        Keep store paths registered within this time window. Avoids deleting
-        build dependencies fetched during a recent build.
-      '';
-    };
-
-    noVacuum = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Skip the SQLite VACUUM after garbage collection. Enable on busy
-        builders, where concurrent nix-daemon readers prevent cleanup of
-        the database-sized WAL that VACUUM produces; see the README.
-      '';
-    };
-
-    chunkSize = lib.mkOption {
-      type = lib.types.nullOr lib.types.ints.positive;
-      default = null;
-      description = ''
-        Number of dead paths invalidated per database transaction. Lower
-        values keep the WAL (and its disk use) smaller during deletion at
-        the cost of more checkpoints; null uses the default (65536).
-      '';
-    };
-
-    extraArgs = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Extra arguments to pass to fast-nix-gc.";
-    };
   };
 
   options.services.fast-nix-optimise = {
-    enable = lib.mkEnableOption "fast-nix-optimise, a faster nix-store --optimise";
-
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = cfg.package;
-      defaultText = lib.literalExpression "config.services.fast-nix-gc.package";
-      description = "Package providing the fast-nix-optimise binary.";
-    };
-
-    automatic = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Run store deduplication automatically on a schedule.";
-    };
-
     dates = lib.mkOption {
       type = with lib.types; either singleLineStr (listOf str);
       apply = lib.toList;
@@ -143,25 +60,6 @@ in
       default = true;
       description = "Run on next boot if a scheduled run was missed.";
     };
-
-    minSize = lib.mkOption {
-      type = lib.types.nullOr lib.types.ints.unsigned;
-      default = null;
-      example = 4096;
-      description = "Skip files smaller than this many bytes.";
-    };
-
-    jobs = lib.mkOption {
-      type = lib.types.nullOr lib.types.ints.positive;
-      default = null;
-      description = "Concurrency. Defaults to the number of CPUs.";
-    };
-
-    extraArgs = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Extra arguments to pass to fast-nix-optimise.";
-    };
   };
 
   config = lib.mkMerge [
@@ -184,27 +82,7 @@ in
         path = [ config.nix.package ];
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = lib.escapeShellArgs (
-            [ "${cfg.package}/bin/fast-nix-gc" ]
-            ++ lib.optionals (cfg.deleteOlderThan != null) [
-              "--delete-older-than"
-              cfg.deleteOlderThan
-            ]
-            ++ lib.optionals (cfg.ensureFree != null) [
-              "--ensure-free"
-              cfg.ensureFree
-            ]
-            ++ lib.optionals (cfg.keepRecent != null) [
-              "--keep-recent"
-              cfg.keepRecent
-            ]
-            ++ lib.optional cfg.noVacuum "--no-vacuum"
-            ++ lib.optionals (cfg.chunkSize != null) [
-              "--chunk-size"
-              (toString cfg.chunkSize)
-            ]
-            ++ cfg.extraArgs
-          );
+          ExecStart = lib.escapeShellArgs cfg.argv;
         };
         startAt = lib.optionals cfg.automatic cfg.dates;
         restartIfChanged = false;
@@ -237,18 +115,7 @@ in
         path = [ config.nix.package ];
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = lib.escapeShellArgs (
-            [ "${ocfg.package}/bin/fast-nix-optimise" ]
-            ++ lib.optionals (ocfg.minSize != null) [
-              "--min-size"
-              (toString ocfg.minSize)
-            ]
-            ++ lib.optionals (ocfg.jobs != null) [
-              "--jobs"
-              (toString ocfg.jobs)
-            ]
-            ++ ocfg.extraArgs
-          );
+          ExecStart = lib.escapeShellArgs ocfg.argv;
         };
         startAt = lib.optionals ocfg.automatic ocfg.dates;
         restartIfChanged = false;

--- a/nix/service-options.nix
+++ b/nix/service-options.nix
@@ -76,6 +76,17 @@ in
       '';
     };
 
+    gcRootsDirs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "/mnt/extra-roots" ];
+      description = ''
+        Extra directories to scan for GC roots, treated like the standard
+        gcroots directory. Nix only scans its own state directories; this
+        keeps roots that live elsewhere from being collected.
+      '';
+    };
+
     extraArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -152,6 +163,10 @@ in
       "--chunk-size"
       (toString cfg.chunkSize)
     ]
+    ++ lib.concatMap (d: [
+      "--gc-roots-dir"
+      d
+    ]) cfg.gcRootsDirs
     ++ cfg.extraArgs;
 
     services.fast-nix-optimise.argv = [

--- a/nix/service-options.nix
+++ b/nix/service-options.nix
@@ -1,0 +1,170 @@
+# Platform-independent options shared by the NixOS and nix-darwin modules.
+# Scheduling options (systemd dates vs launchd intervals) live in the
+# platform modules that import this file.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.fast-nix-gc;
+  ocfg = config.services.fast-nix-optimise;
+in
+{
+  options.services.fast-nix-gc = {
+    enable = lib.mkEnableOption "fast-nix-gc, a faster nix-collect-garbage";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix { }";
+      description = "fast-nix-gc package to use.";
+    };
+
+    automatic = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Run garbage collection automatically on a schedule.";
+    };
+
+    deleteOlderThan = lib.mkOption {
+      type = lib.types.nullOr lib.types.singleLineStr;
+      default = null;
+      example = "30d";
+      description = "Delete profile generations older than this.";
+    };
+
+    ensureFree = lib.mkOption {
+      type = lib.types.nullOr lib.types.singleLineStr;
+      default = null;
+      example = "50G";
+      description = ''
+        Free space until this much is available, then stop. Accepts an
+        absolute size like "50G" or a percentage of the store's filesystem
+        like "20%".
+      '';
+    };
+
+    keepRecent = lib.mkOption {
+      type = lib.types.nullOr lib.types.singleLineStr;
+      default = null;
+      example = "1d";
+      description = ''
+        Keep store paths registered within this time window. Avoids deleting
+        build dependencies fetched during a recent build.
+      '';
+    };
+
+    noVacuum = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Skip the SQLite VACUUM after garbage collection. Enable on busy
+        builders, where concurrent nix-daemon readers prevent cleanup of
+        the database-sized WAL that VACUUM produces; see the README.
+      '';
+    };
+
+    chunkSize = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      description = ''
+        Number of dead paths invalidated per database transaction. Lower
+        values keep the WAL (and its disk use) smaller during deletion at
+        the cost of more checkpoints; null uses the default (65536).
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments to pass to fast-nix-gc.";
+    };
+
+    argv = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      internal = true;
+      readOnly = true;
+    };
+  };
+
+  options.services.fast-nix-optimise = {
+    enable = lib.mkEnableOption "fast-nix-optimise, a faster nix-store --optimise";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = config.services.fast-nix-gc.package;
+      defaultText = lib.literalExpression "config.services.fast-nix-gc.package";
+      description = "Package providing the fast-nix-optimise binary.";
+    };
+
+    automatic = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Run store deduplication automatically on a schedule.";
+    };
+
+    minSize = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.unsigned;
+      default = null;
+      example = 4096;
+      description = "Skip files smaller than this many bytes.";
+    };
+
+    jobs = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      description = "Concurrency. Defaults to the number of CPUs.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra arguments to pass to fast-nix-optimise.";
+    };
+
+    argv = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      internal = true;
+      readOnly = true;
+    };
+  };
+
+  config = {
+    services.fast-nix-gc.argv = [
+      "${cfg.package}/bin/fast-nix-gc"
+    ]
+    ++ lib.optionals (cfg.deleteOlderThan != null) [
+      "--delete-older-than"
+      cfg.deleteOlderThan
+    ]
+    ++ lib.optionals (cfg.ensureFree != null) [
+      "--ensure-free"
+      cfg.ensureFree
+    ]
+    ++ lib.optionals (cfg.keepRecent != null) [
+      "--keep-recent"
+      cfg.keepRecent
+    ]
+    ++ lib.optional cfg.noVacuum "--no-vacuum"
+    ++ lib.optionals (cfg.chunkSize != null) [
+      "--chunk-size"
+      (toString cfg.chunkSize)
+    ]
+    ++ cfg.extraArgs;
+
+    services.fast-nix-optimise.argv = [
+      "${ocfg.package}/bin/fast-nix-optimise"
+    ]
+    ++ lib.optionals (ocfg.minSize != null) [
+      "--min-size"
+      (toString ocfg.minSize)
+    ]
+    ++ lib.optionals (ocfg.jobs != null) [
+      "--jobs"
+      (toString ocfg.jobs)
+    ]
+    ++ ocfg.extraArgs;
+  };
+}

--- a/scripts/wait-for-buildbot.sh
+++ b/scripts/wait-for-buildbot.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Poll a commit's buildbot check run until it finishes. Lets a normal,
+# unprivileged CI job run only after nixbot reports success, without the
+# secret/cache exposure of a status-event-triggered workflow.
+#
+# Usage: wait-for-buildbot.sh <sha> [check-name] [timeout-seconds]
+# Requires gh authenticated via GH_TOKEN.
+set -euo pipefail
+
+sha="$1"
+check="${2:-buildbot/nix-build}"
+timeout="${3:-3600}"
+deadline=$(($(date +%s) + timeout))
+
+while :; do
+  read -r status conclusion < <(
+    gh api "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs" \
+      --jq "([.check_runs[] | select(.name==\"$check\")][0]) | \"\(.status // \"pending\") \(.conclusion // \"\")\""
+  )
+  echo "nixbot check ($check): status=$status conclusion=$conclusion"
+  if [ "$status" = "completed" ]; then
+    [ "$conclusion" = "success" ] && exit 0
+    echo "nixbot concluded: $conclusion" >&2
+    exit 1
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "timed out waiting for $check" >&2
+    exit 1
+  fi
+  sleep 30
+done


### PR DESCRIPTION
Adds `--gc-roots-dir` (closes #35), factors shared service options, adds a nix-darwin module, and a macOS workflow that builds and activates it.