### PR TITLE
common: gate anyhow::Context import to linux

### DIFF
--- a/.github/workflows/darwin-module.yaml
+++ b/.github/workflows/darwin-module.yaml
@@ -37,7 +37,11 @@ jobs:
             [ -e "$f" ] && sudo mv "$f" "$f.before-nix-darwin" || true
           done
       # Activation coverage: install the launchd daemons on the runner.
-      - run: sudo nix run github:nix-darwin/nix-darwin -- switch --flake '.#ci'
+      # root nix has no token, so forward the workflow one to avoid the
+      # unauthenticated github: API rate limit.
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: sudo env "NIX_CONFIG=access-tokens = github.com=$GH_TOKEN" nix run github:nix-darwin/nix-darwin -- switch --flake '.#ci'
       - name: Verify launchd daemons are loaded
         run: |
           sudo launchctl print system/org.nixos.fast-nix-gc

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod db;
 pub mod logging;
 
-use anyhow::{Context, Result};
+#[cfg(target_os = "linux")]
+use anyhow::Context;
+use anyhow::Result;
 use std::path::Path;
 
 /// Enter a private mount namespace so the rw remount in


### PR DESCRIPTION

Context is only used by the linux make_store_writable via .context(); on
darwin the import is unused and trips warn(unused_imports).
