### PR TITLE
gc: prune stale gcroots/auto entries under --delete-older-than

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ with rayon.
 fast-nix-gc [OPTIONS]
 
   -d, --delete-old              Remove old profile generations
-      --delete-older-than SPEC  Delete generations older than SPEC (e.g. 30d, 4h)
+      --delete-older-than SPEC  Delete generations and stale gcroots/auto
+                                entries older than SPEC (e.g. 30d, 4h)
       --dry-run                 Show what would be done
       --ensure-free SIZE        Free until SIZE is available (e.g. 50G or 20%)
       --keep-recent SPEC        Keep paths registered within SPEC (e.g. 1d)
       --no-vacuum               Skip the database VACUUM after deletion
+      --no-prune-devshell-roots Keep stale nix-direnv devshell GC roots
+      --no-prune-auto-roots     Keep other stale gcroots/auto links
       --chunk-size N            Dead paths per delete transaction [default: 65536]
       --keep-outputs BOOL       Override the keep-outputs nix.conf setting
       --keep-derivations BOOL   Override the keep-derivations nix.conf setting
@@ -30,6 +33,27 @@ fast-nix-gc [OPTIONS]
       --store-dir PATH          Nix store directory [default: /nix/store]
       --state-dir PATH          Nix state directory [default: /nix/var/nix]
 ```
+
+### Stale GC roots
+
+`gcroots/auto` accumulates indirect roots forever: nix-direnv devshells of
+abandoned projects and forgotten `nix build` result links pin their whole
+closures. With `--delete-older-than`, fast-nix-gc also prunes these:
+
+- **devshell roots** (targets under a `.direnv/` directory) go when the
+  shell was not *loaded* within the window, judged by the newest
+  atime/mtime of the cached `.direnv/*.rc` — nix-direnv sources it on
+  every load, so relatime keeps the atime current to the day. On
+  `noatime` mounts the signal degrades to the last rebuild. Opt out with
+  `--no-prune-devshell-roots`.
+- **all other auto roots** go when the link itself is older than the
+  window (its mtime is the moment Nix registered the root). Opt out with
+  `--no-prune-auto-roots`.
+
+Pruning only unroots: the closure is collected by the same run, the
+project's `result` / `.direnv` symlinks are left in place (now dangling),
+and nix-direnv re-registers on the next visit, at worst rebuilding the
+shell.
 
 ## fast-nix-optimise
 
@@ -96,9 +120,11 @@ Replaces `nix.gc` and `nix.optimise`:
 | `dates` | `"03:15"` | When to run (`systemd.time(7)` calendar event) |
 | `randomizedDelaySec` | `"0"` | Random delay before each run |
 | `persistent` | `true` | Run on next boot if a scheduled run was missed |
-| `deleteOlderThan` | `null` | Remove profile generations older than e.g. `"30d"` |
+| `deleteOlderThan` | `null` | Remove profile generations and stale gcroots/auto entries older than e.g. `"30d"` |
 | `ensureFree` | `null` | Stop once this much disk is free, e.g. `"50G"` or `"20%"` of the store's filesystem |
 | `keepRecent` | `null` | Pin paths registered within e.g. `"1d"` |
+| `pruneDevshellRoots` | `true` | With `deleteOlderThan`: drop nix-direnv devshell roots not loaded within the window |
+| `pruneAutoRoots` | `true` | With `deleteOlderThan`: drop other gcroots/auto links registered before the window |
 | `noVacuum` | `false` | Skip the post-GC database VACUUM (see below) |
 | `chunkSize` | `null` | Dead paths per delete transaction (default 65536) |
 | `gcRootsDirs` | `[ ]` | Extra directories to scan for GC roots, e.g. `[ "/mnt/extra-roots" ]` |

--- a/crates/gc/src/auto_roots.rs
+++ b/crates/gc/src/auto_roots.rs
@@ -1,0 +1,151 @@
+//! Stale gcroots/auto pruning (--delete-older-than).
+//!
+//! `gcroots/auto` accumulates indirect roots forever: nix-direnv devshells
+//! of abandoned projects and old `nix build` result links keep their
+//! closures alive until the user hunts them down by hand. When the user
+//! already asked for age-based cleanup via --delete-older-than, prune these
+//! too:
+//!
+//! - devshell roots (target under a `.direnv/` directory): stale when the
+//!   newest atime/mtime across the project's `.direnv/*.rc` files is older
+//!   than the cutoff. nix-direnv sources the cached rc on every load, so
+//!   its atime tracks the last load (day granularity under relatime; under
+//!   noatime this degrades to the last rebuild). A `.direnv` without rc
+//!   files falls back to the auto link's own mtime.
+//! - all other auto roots: stale when the auto link's own mtime (= the
+//!   moment Nix registered the root) is older than the cutoff.
+//!
+//! Removing the auto link only unroots: the store paths are collected by
+//! the GC pass that follows, and nix-direnv re-registers on the next visit
+//! to a pruned project. Dangling links are not our job — root discovery
+//! removes them (see roots::remove_stale_auto_link).
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Component, Path};
+use std::time::SystemTime;
+
+/// Prune symlinks in `<state_dir>/gcroots/auto` whose last use predates
+/// `cutoff`. `prune_devshell` / `prune_other` correspond to the
+/// `--no-prune-devshell-roots` / `--no-prune-auto-roots` opt-outs.
+pub fn prune_stale_auto_roots(
+    state_dir: &Path,
+    cutoff: SystemTime,
+    prune_devshell: bool,
+    prune_other: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let auto = state_dir.join("gcroots/auto");
+    let entries = match fs::read_dir(&auto) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("opening {}", auto.display())),
+    };
+
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading {}", auto.display()))?;
+        let link = entry.path();
+        if !entry.file_type().is_ok_and(|t| t.is_symlink()) {
+            continue;
+        }
+        let Ok(target) = fs::read_link(&link) else {
+            continue;
+        };
+        // Dangling roots are removed during root discovery, not here.
+        if fs::symlink_metadata(&target).is_err() {
+            continue;
+        }
+
+        let (last_used, kind) = match direnv_dir(&target) {
+            Some(direnv) => {
+                if !prune_devshell {
+                    continue;
+                }
+                match newest_rc_activity(&direnv) {
+                    Some(t) => (t, "unused devshell"),
+                    // No cached rc to judge by; the link's registration
+                    // time is the only signal left.
+                    None => match link_mtime(&link) {
+                        Some(t) => (t, "unused devshell"),
+                        None => continue,
+                    },
+                }
+            }
+            None => {
+                if !prune_other {
+                    continue;
+                }
+                match link_mtime(&link) {
+                    Some(t) => (t, "old root"),
+                    None => continue,
+                }
+            }
+        };
+
+        if last_used >= cutoff {
+            continue;
+        }
+        if dry_run {
+            println!("would remove {}: {}", kind, target.display());
+        } else {
+            log::info!("removing {}: {}", kind, target.display());
+            fs::remove_file(&link).with_context(|| format!("removing {}", link.display()))?;
+        }
+    }
+    Ok(())
+}
+
+/// If `target` lies inside a `.direnv` directory, return the path of that
+/// `.direnv` directory. Component match, not substring: a project named
+/// "foo.direnv" must not qualify.
+fn direnv_dir(target: &Path) -> Option<std::path::PathBuf> {
+    let mut dir = std::path::PathBuf::new();
+    for comp in target.components() {
+        dir.push(comp);
+        if matches!(comp, Component::Normal(name) if name == ".direnv") {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+/// Newest atime/mtime across the `.direnv/*.rc` files, i.e. the last time
+/// nix-direnv loaded (atime) or rebuilt (mtime) the devshell.
+fn newest_rc_activity(direnv: &Path) -> Option<SystemTime> {
+    let mut newest: Option<SystemTime> = None;
+    for entry in fs::read_dir(direnv).ok()?.flatten() {
+        if entry.path().extension().is_none_or(|e| e != "rc") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        for t in [meta.accessed().ok(), meta.modified().ok()] {
+            if let Some(t) = t
+                && newest.is_none_or(|n| t > n)
+            {
+                newest = Some(t);
+            }
+        }
+    }
+    newest
+}
+
+fn link_mtime(link: &Path) -> Option<SystemTime> {
+    fs::symlink_metadata(link).ok()?.modified().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direnv_dir_matches_component_only() {
+        assert_eq!(
+            direnv_dir(Path::new("/p/x/.direnv/flake-profile-1-link")),
+            Some(std::path::PathBuf::from("/p/x/.direnv"))
+        );
+        assert_eq!(direnv_dir(Path::new("/p/x.direnv/link")), None);
+        assert_eq!(direnv_dir(Path::new("/p/x/result")), None);
+    }
+}

--- a/crates/gc/src/lib.rs
+++ b/crates/gc/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auto_roots;
 pub mod gc;
 pub mod gc_socket;
 pub mod profiles;

--- a/crates/gc/src/main.rs
+++ b/crates/gc/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use fast_nix_common::unshare_mount_namespace;
-use fast_nix_gc::{db, format_size, gc, profiles};
+use fast_nix_gc::{auto_roots, db, format_size, gc, profiles};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 
@@ -8,6 +8,8 @@ struct Args {
     delete_old: bool,
     delete_older_than: Option<String>,
     dry_run: bool,
+    no_prune_devshell_roots: bool,
+    no_prune_auto_roots: bool,
     ensure_free: Option<EnsureFree>,
     keep_recent: Option<String>,
     no_vacuum: bool,
@@ -99,6 +101,9 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         println!("      --keep-recent SPEC        Keep paths registered within SPEC (e.g. 7d)");
         println!("                                (pinned paths are never freed by --ensure-free)");
         println!("      --no-vacuum               Skip the database VACUUM after deletion");
+        println!("      --no-prune-devshell-roots Keep stale nix-direnv devshell GC roots");
+        println!("                                (--delete-older-than removes them by default)");
+        println!("      --no-prune-auto-roots     Keep other stale gcroots/auto links");
         println!(
             "      --chunk-size N            Dead paths per delete transaction [default: 65536]"
         );
@@ -120,6 +125,8 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
         delete_old,
         delete_older_than,
         dry_run: pargs.contains("--dry-run"),
+        no_prune_devshell_roots: pargs.contains("--no-prune-devshell-roots"),
+        no_prune_auto_roots: pargs.contains("--no-prune-auto-roots"),
         ensure_free: pargs.opt_value_from_fn("--ensure-free", parse_ensure_free)?,
         keep_recent: pargs.opt_value_from_str("--keep-recent")?,
         no_vacuum: pargs.contains("--no-vacuum"),
@@ -143,6 +150,8 @@ fn parse_args_from(args: Vec<std::ffi::OsString>) -> Result<Args> {
             "--delete-old",
             "--delete-older-than",
             "--dry-run",
+            "--no-prune-devshell-roots",
+            "--no-prune-auto-roots",
             "--ensure-free",
             "--keep-recent",
             "--no-vacuum",
@@ -215,6 +224,17 @@ fn main() -> Result<()> {
             .try_for_each(|dir| {
                 profiles::remove_old_generations(dir, delete_older_cutoff, args.dry_run)
             })?;
+    }
+    // Before root discovery, so pruned links never register as roots in
+    // this run; see auto_roots.rs for the staleness signals.
+    if let Some(cutoff) = delete_older_cutoff {
+        auto_roots::prune_stale_auto_roots(
+            &args.state_dir,
+            cutoff,
+            !args.no_prune_devshell_roots,
+            !args.no_prune_auto_roots,
+            args.dry_run,
+        )?;
     }
 
     let max_freed = if let Some(ensure_free) = args.ensure_free {

--- a/crates/gc/tests/integration.rs
+++ b/crates/gc/tests/integration.rs
@@ -1351,3 +1351,188 @@ fn gc_vacuums_db_after_mass_deletion() {
         "db not vacuumed: before={before} after={after}"
     );
 }
+
+/// Helpers for the stale-auto-root pruning tests (--delete-older-than).
+mod stale_roots {
+    use super::*;
+    use nix::sys::stat::UtimensatFlags;
+    use nix::sys::time::TimeSpec;
+
+    pub const OLD: i64 = 1_000_000; // 1970; far past any cutoff
+    pub const RECENT_SLACK: i64 = 60;
+
+    pub fn now() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+
+    pub fn set_times(path: &std::path::Path, atime: i64, mtime: i64) {
+        nix::sys::stat::utimensat(
+            nix::fcntl::AT_FDCWD,
+            path,
+            &TimeSpec::new(atime, 0),
+            &TimeSpec::new(mtime, 0),
+            UtimensatFlags::NoFollowSymlink,
+        )
+        .unwrap();
+    }
+
+    /// A fake nix-direnv project: `<base>/proj/.direnv/flake-profile-1-link`
+    /// pointing at `target`, a cached rc with the given times, and an auto
+    /// root registered for the profile link. Returns the auto link path.
+    pub fn add_devshell_root(
+        store: &TestStore,
+        name: &str,
+        target: &Pkg,
+        rc_atime: i64,
+        rc_mtime: i64,
+    ) -> PathBuf {
+        let direnv = store.dir.path().join(name).join(".direnv");
+        fs::create_dir_all(&direnv).unwrap();
+        let profile = direnv.join("flake-profile-1-link");
+        std::os::unix::fs::symlink(&target.path, &profile).unwrap();
+        let rc = direnv.join("flake-profile-abc.rc");
+        fs::write(&rc, "export FOO=bar").unwrap();
+        set_times(&rc, rc_atime, rc_mtime);
+
+        let auto = store.state_dir.join("gcroots/auto");
+        fs::create_dir_all(&auto).unwrap();
+        let link = auto.join(name);
+        std::os::unix::fs::symlink(&profile, &link).unwrap();
+        link
+    }
+
+    /// A plain auto root (result-link style) whose link mtime is `mtime`.
+    pub fn add_result_root(store: &TestStore, name: &str, target: &Pkg, mtime: i64) -> PathBuf {
+        let user_link = store.dir.path().join(format!("{name}-result"));
+        std::os::unix::fs::symlink(&target.path, &user_link).unwrap();
+        let auto = store.state_dir.join("gcroots/auto");
+        fs::create_dir_all(&auto).unwrap();
+        let link = auto.join(name);
+        std::os::unix::fs::symlink(&user_link, &link).unwrap();
+        set_times(&link, mtime, mtime);
+        link
+    }
+}
+
+#[test]
+fn delete_older_than_prunes_stale_devshell_root() {
+    use stale_roots::*;
+    let store = TestStore::new();
+    let lib = store.add_path("stale-shell", 100);
+    let link = add_devshell_root(&store, "p1", &lib, OLD, OLD);
+
+    store.run_gc_ok(&["--delete-older-than", "30d"]);
+
+    assert!(link.symlink_metadata().is_err(), "stale devshell root kept");
+    assert!(
+        !lib.path.exists() && !store.in_db(&lib),
+        "unrooted path kept"
+    );
+}
+
+#[test]
+fn delete_older_than_keeps_recently_loaded_devshell_root() {
+    use stale_roots::*;
+    let store = TestStore::new();
+    let lib = store.add_path("loaded-shell", 100);
+    // Rebuilt long ago, but loaded just now: atime fresh, mtime old.
+    let link = add_devshell_root(&store, "p1", &lib, now() - RECENT_SLACK, OLD);
+
+    store.run_gc_ok(&["--delete-older-than", "30d"]);
+
+    assert!(
+        link.symlink_metadata().is_ok(),
+        "loaded devshell root pruned"
+    );
+    assert!(
+        lib.path.exists() && store.in_db(&lib),
+        "rooted path deleted"
+    );
+}
+
+#[test]
+fn delete_older_than_prunes_old_result_root_and_keeps_recent() {
+    use stale_roots::*;
+    let store = TestStore::new();
+    let old_lib = store.add_path("old-result", 100);
+    let new_lib = store.add_path("new-result", 100);
+    let old_link = add_result_root(&store, "r-old", &old_lib, OLD);
+    let new_link = add_result_root(&store, "r-new", &new_lib, now() - RECENT_SLACK);
+
+    store.run_gc_ok(&["--delete-older-than", "30d"]);
+
+    assert!(old_link.symlink_metadata().is_err(), "old result root kept");
+    assert!(!old_lib.path.exists(), "unrooted path kept");
+    assert!(
+        new_link.symlink_metadata().is_ok(),
+        "recent result root pruned"
+    );
+    assert!(
+        new_lib.path.exists() && store.in_db(&new_lib),
+        "rooted path deleted"
+    );
+}
+
+#[test]
+fn no_prune_flags_keep_stale_roots() {
+    use stale_roots::*;
+    let store = TestStore::new();
+    let shell = store.add_path("optout-shell", 100);
+    let result = store.add_path("optout-result", 100);
+    let shell_link = add_devshell_root(&store, "p1", &shell, OLD, OLD);
+    let result_link = add_result_root(&store, "r1", &result, OLD);
+
+    store.run_gc_ok(&[
+        "--delete-older-than",
+        "30d",
+        "--no-prune-devshell-roots",
+        "--no-prune-auto-roots",
+    ]);
+
+    assert!(
+        shell_link.symlink_metadata().is_ok(),
+        "opted-out devshell root pruned"
+    );
+    assert!(
+        result_link.symlink_metadata().is_ok(),
+        "opted-out result root pruned"
+    );
+    assert!(shell.path.exists() && result.path.exists());
+}
+
+#[test]
+fn dry_run_reports_but_keeps_stale_roots() {
+    use stale_roots::*;
+    let store = TestStore::new();
+    let lib = store.add_path("dry-shell", 100);
+    let link = add_devshell_root(&store, "p1", &lib, OLD, OLD);
+
+    let out = store.run_gc_ok(&["--delete-older-than", "30d", "--dry-run"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("would remove"), "stdout: {stdout}");
+    assert!(link.symlink_metadata().is_ok(), "dry run removed a root");
+    assert!(
+        lib.path.exists() && store.in_db(&lib),
+        "dry run deleted a path"
+    );
+}
+
+#[test]
+fn delete_old_without_spec_prunes_no_roots() {
+    use stale_roots::*;
+    let store = TestStore::new();
+    let lib = store.add_path("no-spec-shell", 100);
+    let link = add_devshell_root(&store, "p1", &lib, OLD, OLD);
+
+    store.run_gc_ok(&["--delete-old"]);
+
+    assert!(
+        link.symlink_metadata().is_ok(),
+        "-d without age pruned a root"
+    );
+    assert!(lib.path.exists() && store.in_db(&lib));
+}

--- a/nix/service-options.nix
+++ b/nix/service-options.nix
@@ -32,7 +32,13 @@ in
       type = lib.types.nullOr lib.types.singleLineStr;
       default = null;
       example = "30d";
-      description = "Delete profile generations older than this.";
+      description = ''
+        Delete profile generations older than this. Also prunes stale
+        gcroots/auto entries by the same cutoff: nix-direnv devshell roots
+        not loaded within the window and other auto roots (e.g. old
+        `result` links) registered before it. See pruneDevshellRoots /
+        pruneAutoRoots to opt out.
+      '';
     };
 
     ensureFree = lib.mkOption {
@@ -53,6 +59,27 @@ in
       description = ''
         Keep store paths registered within this time window. Avoids deleting
         build dependencies fetched during a recent build.
+      '';
+    };
+
+    pruneDevshellRoots = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        With deleteOlderThan set, remove GC roots of nix-direnv devshells
+        that were not loaded within the window (judged by the atime/mtime
+        of the cached .direnv/*.rc; under noatime mounts this degrades to
+        the last rebuild).
+      '';
+    };
+
+    pruneAutoRoots = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        With deleteOlderThan set, remove non-devshell gcroots/auto links
+        (e.g. from old `nix build` result symlinks) registered before the
+        window.
       '';
     };
 
@@ -150,6 +177,8 @@ in
       "--delete-older-than"
       cfg.deleteOlderThan
     ]
+    ++ lib.optional (!cfg.pruneDevshellRoots) "--no-prune-devshell-roots"
+    ++ lib.optional (!cfg.pruneAutoRoots) "--no-prune-auto-roots"
     ++ lib.optionals (cfg.ensureFree != null) [
       "--ensure-free"
       cfg.ensureFree


### PR DESCRIPTION
gcroots/auto accumulates indirect roots forever: nix-direnv devshells of abandoned projects and forgotten nix-build result links pin their whole closures. When the user already asked for age-based cleanup, prune these too, before root discovery:

- devshell roots (target under .direnv/) go when the shell was not loaded within the window, judged by the newest atime/mtime of the cached .direnv/*.rc: nix-direnv sources it on every load, so relatime keeps the atime current to the day (noatime degrades to last rebuild).
- other auto roots go by the link's own mtime (registration time).

Opt-outs: --no-prune-devshell-roots / --no-prune-auto-roots, mirrored as module options pruneDevshellRoots / pruneAutoRoots (default true). Dangling links stay the job of root discovery.